### PR TITLE
audio: Allow AudioStreamGet to return 0 in RunAudio.

### DIFF
--- a/Source/ThirdParty/SDL/src/audio/SDL_audio.c
+++ b/Source/ThirdParty/SDL/src/audio/SDL_audio.c
@@ -745,7 +745,7 @@ SDL_RunAudio(void *devicep)
                 int got;
                 data = SDL_AtomicGet(&device->enabled) ? current_audio.impl.GetDeviceBuf(device) : NULL;
                 got = SDL_AudioStreamGet(device->stream, data ? data : device->work_buffer, device->spec.size);
-                SDL_assert((got < 0) || (got == device->spec.size));
+                SDL_assert((got <= 0) || (got == device->spec.size));
 
                 if (data == NULL) {  /* device is having issues... */
                     const Uint32 delay = ((device->spec.samples * 1000) / device->spec.freq);


### PR DESCRIPTION
While we should normally expect _something_ from the stream based on the
AudioStreamAvailable check, it's possible for a device change to flush the
stream at an inconvenient time, causing this function to return 0.

Thing is, this is harmless. Either data will be NULL and the result won't matter
anyway, or the data buffer will be zeroed out and the output will just be
silence for the brief moment that the device change is occurring. Both scenarios
work themselves out, and testing on Windows shows that this behavior is safe.