### PR TITLE
Skip empty geometries

### DIFF
--- a/Source/Tests/Graphics/StaticModel.cpp
+++ b/Source/Tests/Graphics/StaticModel.cpp
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2017-2021 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR rhs
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR rhsWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR rhs DEALINGS IN
+// THE SOFTWARE.
+//
+#include "../CommonUtils.h"
+#include "../ModelUtils.h"
+
+#include <Urho3D/Scene/Scene.h>
+#include <Urho3D/Graphics/IndexBuffer.h>
+#include <Urho3D/Graphics/Model.h>
+#include <Urho3D/Graphics/Geometry.h>
+#include <Urho3D/Graphics/StaticModel.h>
+#include <Urho3D/Graphics/CustomGeometry.h>
+
+TEST_CASE("Empty geometry skipped in batch")
+{
+    auto context = Tests::CreateCompleteTestContext();
+    auto scene = MakeShared<Scene>(context);
+    auto node = scene->CreateChild();
+    auto staticModel = node->CreateComponent<StaticModel>();
+
+    // Create model with empty geometry
+    auto geometry = MakeShared<Geometry>(context);
+    auto model = MakeShared<Model>(context);
+    auto vb = MakeShared<VertexBuffer>(context);
+    model->SetVertexBuffers({vb}, {}, {});
+    auto ib = MakeShared<IndexBuffer>(context);
+    REQUIRE(model->SetIndexBuffers({ib}));
+    REQUIRE(geometry->SetVertexBuffer(0, vb));
+    geometry->SetIndexBuffer(ib);
+    REQUIRE(geometry->SetDrawRange(PrimitiveType::LINE_LIST, 0, 0));
+    model->SetNumGeometries(1);
+    REQUIRE(model->SetNumGeometryLodLevels(0, 1));
+    REQUIRE(model->SetGeometry(0, 0, geometry));
+
+    // Check that geometry is set correctly to null
+    staticModel->SetModel(model);
+    auto& batches = staticModel->GetBatches();
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].geometry_ == nullptr);
+}
+
+
+TEST_CASE("Non-empty geometry is present at batch")
+{
+    auto context = Tests::CreateCompleteTestContext();
+    auto scene = MakeShared<Scene>(context);
+    auto node = scene->CreateChild();
+    auto staticModel = node->CreateComponent<StaticModel>();
+
+    // Create model with geometry
+    auto geometry = MakeShared<Geometry>(context);
+    auto model = MakeShared<Model>(context);
+    auto vb = MakeShared<VertexBuffer>(context);
+    model->SetVertexBuffers({vb}, {}, {});
+    auto ib = MakeShared<IndexBuffer>(context);
+    ib->SetSize(2, false);
+    REQUIRE(model->SetIndexBuffers({ib}));
+    REQUIRE(geometry->SetVertexBuffer(0, vb));
+    geometry->SetIndexBuffer(ib);
+    REQUIRE(geometry->SetDrawRange(PrimitiveType::LINE_LIST, 0, 2));
+    model->SetNumGeometries(1);
+    REQUIRE(model->SetNumGeometryLodLevels(0, 1));
+    REQUIRE(model->SetGeometry(0, 0, geometry));
+
+    // Check that geometry is set correctly to null
+    staticModel->SetModel(model);
+    auto& batches = staticModel->GetBatches();
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].geometry_ == geometry);
+}

--- a/Source/Urho3D/Graphics/CustomGeometry.cpp
+++ b/Source/Urho3D/Graphics/CustomGeometry.cpp
@@ -225,7 +225,7 @@ void CustomGeometry::SetNumGeometries(unsigned num)
         if (!geometries_[i])
             geometries_[i] = context_->CreateObject<Geometry>();
 
-        batches_[i].geometry_ = geometries_[i];
+        batches_[i].geometry_ = GetGeometryIfNotEmpty(geometries_[i]);
     }
 }
 

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -306,6 +306,11 @@ unsigned Drawable::GetShadowMaskInZone() const
     return zoneShadowMask & shadowMask_;
 }
 
+Geometry* Drawable::GetGeometryIfNotEmpty(Geometry* geometry)
+{
+    return (geometry && geometry->GetIndexCount()) ? geometry : nullptr;
+}
+
 unsigned Drawable::RecalculatePipelineStateHash() const
 {
     unsigned hash = 0;

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -418,6 +418,8 @@ public:
 protected:
     /// Recalculate hash. Shall be save to call from multiple threads as long as the object is not changing.
     unsigned RecalculatePipelineStateHash() const override;
+    /// Get Geometry pointer if the source one is not null or empty.
+    static Geometry* GetGeometryIfNotEmpty(Geometry* geometry);
 
     /// Handle node being assigned.
     void OnNodeSet(Node* node) override;

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -417,7 +417,7 @@ void StaticModel::ResetLodLevels()
     {
         if (!geometries_[i].size())
             geometries_[i].resize(1);
-        batches_[i].geometry_ = geometries_[i][0];
+        batches_[i].geometry_ = GetGeometryIfNotEmpty(geometries_[i][0]);
         geometryData_[i].lodLevel_ = 0;
     }
 
@@ -446,7 +446,7 @@ void StaticModel::CalculateLodLevels()
         if (geometryData_[i].lodLevel_ != newLodLevel)
         {
             geometryData_[i].lodLevel_ = newLodLevel;
-            batches_[i].geometry_ = batchGeometries[newLodLevel];
+            batches_[i].geometry_ = GetGeometryIfNotEmpty(batchGeometries[newLodLevel]);
         }
     }
 }


### PR DESCRIPTION
Having an empty geometry with no vertices is a valid case. For instance a MDL file may have lods where each LOD has it's own material. To implement this scenario only one geometry in each LOD level going to have indices.