### PR TITLE
Android InnerIterator problem

### DIFF
--- a/Source/Urho3D/Container/MultiVector.h
+++ b/Source/Urho3D/Container/MultiVector.h
@@ -114,7 +114,8 @@ public:
         /// Compare equal.
         bool operator==(const BaseIterator& rhs) const
         {
-            return outer_ == rhs.outer_ && inner_ == rhs.inner_;
+            // InnerIterator{} != InnerIterator{}, because iterator construct default not defined with container
+            return (outer_ == outerEnd_ && rhs.outer_ == rhs.outerEnd_) || (outer_ == rhs.outer_ && inner_ == rhs.inner_);
         }
 
         /// Compare not equal.


### PR DESCRIPTION
InnerIterator{} != InnerIterator{}, because iterator construct default not defined with container