### PR TITLE
Set high dpi to true to make engine to draw the entire window

### DIFF
--- a/Source/Samples/SamplesManager.cpp
+++ b/Source/Samples/SamplesManager.cpp
@@ -155,7 +155,7 @@ void SamplesManager::Setup()
     engineParameters_[EP_FULL_SCREEN]  = false;
     engineParameters_[EP_HEADLESS]     = false;
     engineParameters_[EP_SOUND]        = true;
-    engineParameters_[EP_HIGH_DPI]     = false;
+    engineParameters_[EP_HIGH_DPI]     = true;
     engineParameters_[EP_RESOURCE_PATHS] = "CoreData;Data";
 #if MOBILE
     engineParameters_[EP_ORIENTATIONS] = "Portrait";

--- a/Source/Tools/Editor/Editor.cpp
+++ b/Source/Tools/Editor/Editor.cpp
@@ -151,7 +151,7 @@ void Editor::Setup()
     engineParameters_[EP_HIGH_DPI] = true;
     engineParameters_[EP_SYSTEMUI_FLAGS] = engineParameters_[EP_SYSTEMUI_FLAGS].GetUInt() | ImGuiConfigFlags_ViewportsEnable /*| ImGuiConfigFlags_DpiEnableScaleViewports*/;
 #else
-    engineParameters_[EP_HIGH_DPI] = false;
+    engineParameters_[EP_HIGH_DPI] = true;
 #endif
     // Load editor settings
     {


### PR DESCRIPTION
<img width="1136" alt="Screen Shot 2021-12-15 at 22 44 07" src="https://user-images.githubusercontent.com/992894/146200318-daea5154-c132-4429-9833-c1152a2cd0b1.png">

Without this engine only draws a quarter of the window. So "false" value is broken on mac. I suggest to set it to true in order to let mac users to try SamplesManager without troubles.