### PR TITLE
Cast shadows by default

### DIFF
--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -69,7 +69,7 @@ Drawable::Drawable(Context* context, DrawableFlags drawableFlags) :
     boundingBox_(0.0f, 0.0f),
     drawableFlags_(drawableFlags),
     worldBoundingBoxDirty_(true),
-    castShadows_(false),
+    castShadows_(true),
     occluder_(false),
     occludee_(true),
     updateQueued_(false),


### PR DESCRIPTION
To quote @JTippetts:

> It is kind of weird that the default is still off, though, in this day and age. I could see 10 or 15 years ago, for performance reasons or something maybe, but now?

So I decided to create a PR to fix that ;-)