### PR TITLE
GraphPinRef

### DIFF
--- a/Source/Tests/Resource/Graph.cpp
+++ b/Source/Tests/Resource/Graph.cpp
@@ -216,8 +216,8 @@ TEST_CASE("Graph serialization roundtrip")
     track.Commit();
     nodeC->GetOrAddProperty("spline") = track;
 
-    auto& out = nodeA->GetOrAddOutput("out");
-    auto& enter = nodeC->GetOrAddEnter("enter");
+    auto out = nodeA->GetOrAddOutput("out");
+    auto enter = nodeC->GetOrAddEnter("enter");
 
     CHECK(nodeB->GetOrAddInput("in").GetPin()->ConnectTo(out));
     nodeB->GetOrAddOutput("out");

--- a/Source/Urho3D/Resource/Graph.cpp
+++ b/Source/Urho3D/Resource/Graph.cpp
@@ -50,6 +50,41 @@ void Graph::Clear()
     }
     nodes_.clear();
 }
+/// Connect exit pin to enter pin.
+void Graph::Connect(GraphPinRef<GraphExitPin> pin, GraphPinRef<GraphEnterPin> target) {
+
+}
+
+/// Connect input pin to output pin.
+void Graph::Connect(GraphPinRef<GraphInPin> pin, GraphPinRef<GraphOutPin> target) {
+    
+}
+
+/// Get pin connected to the exit pin.
+GraphPinRef<GraphEnterPin> Graph::GetConnectedPin(GraphExitPin& pin) const
+{
+    if (!pin.targetNode_)
+        return {};
+
+    if (auto target = GetNode(pin.targetNode_))
+    {
+        return target->GetEnter(pin.targetPin_);
+    }
+    return {};
+}
+
+/// Get pin connected to the input pin.
+GraphPinRef<GraphOutPin> Graph::GetConnectedPin(GraphInPin& pin) const
+{
+    if (!pin.targetNode_)
+        return {};
+
+    if (auto target = GetNode(pin.targetNode_))
+    {
+        return target->GetOutput(pin.targetPin_);
+    }
+    return {};
+}
 
 void Graph::GetNodeIds(ea::vector<unsigned>& ids) const
 {

--- a/Source/Urho3D/Resource/Graph.h
+++ b/Source/Urho3D/Resource/Graph.h
@@ -27,6 +27,11 @@
 namespace Urho3D
 {
 class GraphNode;
+class GraphExitPin;
+class GraphEnterPin;
+class GraphInPin;
+class GraphOutPin;
+template <typename PinType> class GraphPinRef;
 
 /// Abstract graph to store connected nodes.
 class URHO3D_API Graph : public Object
@@ -73,6 +78,18 @@ public:
 
     /// Remove all nodes.
     void Clear();
+
+    /// Connect exit pin to enter pin.
+    void Connect(GraphPinRef<GraphExitPin> pin, GraphPinRef<GraphEnterPin> target);
+
+    /// Connect input pin to output pin.
+    void Connect(GraphPinRef<GraphInPin> pin, GraphPinRef<GraphOutPin> target);
+
+    /// Get pin connected to the exit pin.
+    GraphPinRef<GraphEnterPin> GetConnectedPin(GraphExitPin& pin) const;
+
+    /// Get pin connected to the input pin.
+    GraphPinRef<GraphOutPin> GetConnectedPin(GraphInPin& pin) const;
 
 private:
     /// Get free node ID.

--- a/Source/Urho3D/Resource/GraphNode.h
+++ b/Source/Urho3D/Resource/GraphNode.h
@@ -104,13 +104,16 @@ public:
     GraphNode* WithProperty(const ea::string_view name, const Variant& value);
 
     /// Get input pin by name.
-    GraphInPin* GetInput(const ea::string_view name);
+    GraphPinRef<GraphInPin> GetInput(const ea::string_view name);
 
-    /// Get input pins.
-    ea::span<GraphInPin> GetInputs() { return ea::span(inputPins_); }
+    /// Get input pin by index.
+    GraphPinRef<GraphInPin> GetInput(unsigned index);
+
+    /// Get number of input pins.
+    unsigned GetNumInputs() const { return inputPins_.size(); }
 
     /// Get or add input pin.
-    GraphInPin& GetOrAddInput(const ea::string_view name);
+    GraphPinRef<GraphInPin> GetOrAddInput(const ea::string_view name);
 
     /// Add input pin.
     GraphNode* WithInput(const ea::string_view name, VariantType type = VAR_NONE);
@@ -119,37 +122,46 @@ public:
     GraphNode* WithInput(const ea::string_view name, const Variant& value);
 
     /// Add input pin connected to the output pin.
-    GraphNode* WithInput(const ea::string_view name, GraphOutPin* pin, VariantType type = VAR_NONE);
+    GraphNode* WithInput(const ea::string_view name, GraphPinRef<GraphOutPin> pin, VariantType type = VAR_NONE);
 
     /// Get or add output pin.
-    GraphOutPin& GetOrAddOutput(const ea::string_view name);
+    GraphPinRef<GraphOutPin> GetOrAddOutput(const ea::string_view name);
 
     /// Add output pin.
     GraphNode* WithOutput(const ea::string_view name, VariantType type = VAR_NONE);
 
-    /// Get output pin.
-    GraphOutPin* GetOutput(const ea::string_view name);
+    /// Get output pin by name.
+    GraphPinRef<GraphOutPin> GetOutput(const ea::string_view name);
 
-    /// Get output pins.
-    ea::span<GraphOutPin> GetOutputs() { return ea::span(outputPins_); }
+    /// Get output pin by index.
+    GraphPinRef<GraphOutPin> GetOutput(unsigned index);
+
+    /// Get number of output pins.
+    unsigned GetNumOutputs() const { return outputPins_.size(); }
 
     /// Get or add enter pin.
-    GraphEnterPin& GetOrAddEnter(const ea::string_view name);
+    GraphPinRef<GraphEnterPin> GetOrAddEnter(const ea::string_view name);
 
-    /// Get enter pin.
-    GraphEnterPin* GetEnter(const ea::string_view name);
+    /// Get enter pin by name.
+    GraphPinRef<GraphEnterPin> GetEnter(const ea::string_view name);
 
-    /// Get output pins.
-    ea::span<GraphEnterPin> GetEnters() { return ea::span(enterPins_); }
+    /// Get enter pin by index.
+    GraphPinRef<GraphEnterPin> GetEnter(unsigned index);
+
+    /// Get number of enter pins.
+    unsigned GetNumEnters() const { return enterPins_.size(); }
 
     /// Get exit pin.
-    GraphExitPin* GetExit(const ea::string_view name);
+    GraphPinRef<GraphExitPin> GetExit(const ea::string_view name);
+
+    /// Get enter pin by index.
+    GraphPinRef<GraphExitPin> GetExit(unsigned index);
 
     /// Get or add exit pin.
-    GraphExitPin& GetOrAddExit(const ea::string_view name);
+    GraphPinRef<GraphExitPin> GetOrAddExit(const ea::string_view name);
 
-    /// Get exit pins.
-    ea::span<GraphExitPin> GetExits() { return ea::span(exitPins_); }
+    /// Get number of exit pins.
+    unsigned GetNumExits() const { return exitPins_.size(); }
 
     /// Set name of the graph node.
     /// @property
@@ -187,6 +199,12 @@ private:
     ea::fixed_vector<GraphOutPin, 1> outputPins_;
 
     friend class Graph;
+    friend class GraphNode;
 };
+
+template <typename PinType> template<typename OtherPinType> GraphPinRef<OtherPinType> GraphPinRef<PinType>::GetConnectedPin() const
+{
+    return node_->GetGraph()->GetConnectedPin(*pin_);
+}
 
 } // namespace Urho3D

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -31,6 +31,7 @@
 #include "../Resource/Resource.h"
 #include "../Resource/ResourceCache.h"
 #include "../Resource/XMLElement.h"
+#include "Urho3D/IO/MemoryBuffer.h"
 
 namespace Urho3D
 {


### PR DESCRIPTION
Bug fixed in the graph. Unit tests updated to validate access to connected nodes.

To keep ParticleGraph as close as possible to plain data structure the new GraphPinRef is introduced. It encapsulates Node+Pin pair in a single structure to keep reference to a pin of particular node.

Tested on particle graph.