### PR TITLE
pipelineState_ could be null if shader is missing

### DIFF
--- a/Source/Urho3D/RenderPipeline/PostProcessPass.cpp
+++ b/Source/Urho3D/RenderPipeline/PostProcessPass.cpp
@@ -67,7 +67,7 @@ void SimplePostProcessPass::AddShaderResource(TextureUnit unit, Texture* texture
 
 void SimplePostProcessPass::Execute()
 {
-    if (!pipelineState_->IsValid())
+    if (!pipelineState_ || !pipelineState_->IsValid())
         return;
 
     const bool colorReadAndWrite = flags_.Test(PostProcessPassFlag::NeedColorOutputReadAndWrite);

--- a/Source/Urho3D/RenderPipeline/RenderBufferManager.cpp
+++ b/Source/Urho3D/RenderPipeline/RenderBufferManager.cpp
@@ -399,7 +399,7 @@ SharedPtr<PipelineState> RenderBufferManager::CreateQuadPipelineState(BlendMode 
 
 void RenderBufferManager::DrawQuad(ea::string_view debugComment, const DrawQuadParams& params, bool flipVertical)
 {
-    if (!params.pipelineState_->IsValid())
+    if (!params.pipelineState_ || !params.pipelineState_->IsValid())
         return;
 
     Geometry* quadGeometry = renderer_->GetQuadGeometry();


### PR DESCRIPTION
We already report on missing resources to the log so there is no need to crash application here.