### PR TITLE
Plugin app fixes

### DIFF
--- a/Source/Player/Player.cpp
+++ b/Source/Player/Player.cpp
@@ -76,7 +76,7 @@ void Player::Setup()
 
             for (const auto& pair : settings_.engineParameters_)
                 engineParameters_[pair.first] = pair.second;
-            engineParameters_[EP_RESOURCE_PATHS] = "Cache;Resources";
+            engineParameters_[EP_RESOURCE_PATHS] = "Cache;Data;CoreData";
             // Unpacked application is executing. Do not attempt to load paks.
             URHO3D_LOGINFO("This is a developer build executing unpacked application.");
             return;
@@ -198,6 +198,7 @@ void Player::Start()
     }
 
     // Load main scene.
+    if (!settings_.defaultScene_.empty())
     {
         auto* manager = GetSubsystem<SceneManager>();
         Scene* scene = manager->CreateScene();

--- a/Source/Urho3D/Engine/ApplicationSettings.cpp
+++ b/Source/Urho3D/Engine/ApplicationSettings.cpp
@@ -34,12 +34,15 @@ ApplicationSettings::ApplicationSettings(Context* context)
 
 void ApplicationSettings::SerializeInBlock(Archive& archive)
 {
-    SerializeValue(archive, "defaultScene", defaultScene_);
-    SerializeValue(archive, "platforms", platforms_);
-    SerializeMap(archive, "settings", engineParameters_, "value");
+    SerializeOptionalValue(archive, "defaultScene", defaultScene_, EmptyObject{});
+    SerializeOptionalValue(archive, "platforms", platforms_, EmptyObject{});
+    SerializeOptionalValue(archive, "settings", engineParameters_, EmptyObject{},
+        [&](Archive& archive, const char* name, auto& value)
+        { SerializeMap(archive, name, engineParameters_, "value"); });
 
 #if URHO3D_PLUGINS
-    SerializeVector(archive, "plugins", plugins_, "plugin");
+    SerializeOptionalValue(archive, "plugins", plugins_, EmptyObject{},
+        [&](Archive& archive, const char* name, auto& value) { SerializeVector(archive, name, plugins_, "plugin"); });
 #endif
 }
 


### PR DESCRIPTION
- EP_RESOURCE_PATHS fixed. This place was probably missing a fix since default editor folder been changed to "Data" from "Resources". I don't know why CoreData is missing. Overall I'm not sure why there is an override here.
- App should be able to start even if there is no default scene as the plugin may fire up ApplicationState. Editor probably shoud be aware of it.
- ApplicationSettings fields should be optional for convenience.