### PR TITLE
AbstractFilePtr instead of SharedPtr<File>

### DIFF
--- a/Source/Editor/Project/Project.h
+++ b/Source/Editor/Project/Project.h
@@ -81,7 +81,7 @@ struct AnalyzeFileContext
 {
     Context* context_{};
 
-    SharedPtr<File> binaryFile_;
+    AbstractFilePtr binaryFile_;
     SharedPtr<XMLFile> xmlFile_;
     SharedPtr<JSONFile> jsonFile_;
 

--- a/Source/Samples/106_BakedLighting/BakedLighting.cpp
+++ b/Source/Samples/106_BakedLighting/BakedLighting.cpp
@@ -80,7 +80,7 @@ void BakedLighting::CreateScene()
     // Load scene
     scene_ = new Scene(context_);
 
-    SharedPtr<File> file = cache->GetFile("Scenes/BakedLightingExample.xml");
+    const AbstractFilePtr file = cache->GetFile("Scenes/BakedLightingExample.xml");
     scene_->LoadXML(*file);
 
     auto camera = scene_->GetComponent<Camera>(true);

--- a/Source/Samples/108_RenderingShowcase/RenderingShowcase.cpp
+++ b/Source/Samples/108_RenderingShowcase/RenderingShowcase.cpp
@@ -125,7 +125,7 @@ void RenderingShowcase::SetupSelectedScene(bool resetCamera)
     // Load scene content prepared in the editor (XML format). GetFile() returns an open file from the resource system
     // which scene.LoadXML() will read
     const ea::string fileName = Format("Scenes/RenderingShowcase_{}.xml", sceneNames_[sceneIndex_][sceneMode_]);
-    SharedPtr<File> file = cache->GetFile(fileName);
+    const AbstractFilePtr file = cache->GetFile(fileName);
     scene_->LoadXML(*file);
 
     if (resetCamera)

--- a/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
+++ b/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
@@ -71,7 +71,7 @@ void SceneAndUILoad::CreateScene()
 
     // Load scene content prepared in the editor (XML format). GetFile() returns an open file from the resource system
     // which scene.LoadXML() will read
-    SharedPtr<File> file = cache->GetFile("Scenes/SceneLoadExample.xml");
+    AbstractFilePtr file = cache->GetFile("Scenes/SceneLoadExample.xml");
     scene_->LoadXML(*file);
 
     // Create the camera (not included in the scene file)

--- a/Source/Urho3D/CSharp/Managed/FileSystem/File.cs
+++ b/Source/Urho3D/CSharp/Managed/FileSystem/File.cs
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2022-2022 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+namespace Urho3DNet
+{
+    partial class File
+    {
+        string IAbstractFile.GetAbsoluteName()
+        {
+            return AbsoluteName;
+        }
+    }
+}

--- a/Source/Urho3D/CSharp/Scripts/Compiler.cs
+++ b/Source/Urho3D/CSharp/Scripts/Compiler.cs
@@ -19,12 +19,13 @@ namespace Urho3DNet
             Context.Instance.ResourceCache.Scan(scriptRsrcs, scanPath, "*.cs", Urho3D.ScanFiles, true);
             foreach (string fileName in scriptRsrcs)
             {
-                using (File file = Context.Instance.ResourceCache.GetFile(fileName))
+                IAbstractFile file = Context.Instance.ResourceCache.GetFile(fileName);
+                using (file as IDisposable)
                 {
                     // Gather both paths and code text here. If scripts are packaged we must compile them from
                     // text form. However if we are running a development version of application we prefer to
                     // compile scripts directly from file because then we get proper error locations.
-                    if (file.IsPackaged)
+                    if (file is Urho3DNet.File fsFile && fsFile.IsPackaged)
                         scriptCodes.Add(file.ReadString());
                     else
                     {

--- a/Source/Urho3D/CSharp/Swig/RefCounted.i
+++ b/Source/Urho3D/CSharp/Swig/RefCounted.i
@@ -214,10 +214,10 @@
     %typemap(ctype)  Urho3D::SharedPtr<TYPE, BASE> "BASE*"                               // c layer type
     %typemap(imtype) Urho3D::SharedPtr<TYPE, BASE> "global::System.IntPtr"               // pinvoke type
     %typemap(cstype) Urho3D::SharedPtr<TYPE, BASE> "$typemap(cstype, TYPE*)"             // c# type
-    %typemap(in)     Urho3D::SharedPtr<TYPE, BASE> %{ $1 = Urho3D::SharedPtr<TYPE, BASE>(dynamic_cast<TYPE*>($input)); %}    // c to cpp
+    %typemap(in)     Urho3D::SharedPtr<TYPE, BASE> %{ $1 = Urho3D::SharedPtr<TYPE, BASE>(dynamic_cast<TYPE*>($input), $input); %}    // c to cpp
     %typemap(out)    Urho3D::SharedPtr<TYPE, BASE> %{ $result = $1.GetRefCounted(); $1.Detach(); %}          // cpp to c
     %typemap(out)    TYPE*                         %{ $result = $1;          %}          // cpp to c
-    %typemap(csin)   Urho3D::SharedPtr<TYPE, BASE> "global::$nspace.$typemap(cstype, TYPE*).getCPtr($csinput).Handle"      // convert C# to pinvoke
+    %typemap(csin)   Urho3D::SharedPtr<TYPE, BASE> "$csinput.GetInterfaceCPtr().Handle"      // convert C# to pinvoke
     %typemap(csout, excode=SWIGEXCODE) Urho3D::SharedPtr<TYPE, BASE> {                   // convert pinvoke to C#
         var ret = ($typemap(cstype, TYPE*))$typemap(cstype, BASE*).wrap($imcall, true);$excode
         return ret;
@@ -243,7 +243,7 @@
         $*1_ltype $1Ref($input);
         $1 = &$1Ref;
     %}
-    %typemap(out) Urho3D::SharedPtr<TYPE, BASE> & %{ $result = $1->Get(); %}             // cpp to c
+    %typemap(out) Urho3D::SharedPtr<TYPE, BASE> & %{ $result = $1->GetRefCounted(); %}             // cpp to c
 %enddef
 
 // TODO: Fix autoswig script to output these as well.

--- a/Source/Urho3D/CSharp/Swig/Urho3D.i
+++ b/Source/Urho3D/CSharp/Swig/Urho3D.i
@@ -494,6 +494,7 @@ public:
 
 
 // --------------------------------------- Scene ---------------------------------------
+%ignore Urho3D::AsyncProgress;
 %ignore Urho3D::AsyncProgress::resources_;
 %ignore Urho3D::ValueAnimation::GetKeyFrames;
 %ignore Urho3D::Serializable::networkState_;

--- a/Source/Urho3D/Container/Ptr.h
+++ b/Source/Urho3D/Container/Ptr.h
@@ -249,7 +249,6 @@ public:
     /// Convert to a raw pointer.
     operator InterfaceType*() const noexcept { return this->GetPointer(); }    // NOLINT(google-explicit-constructor)
 
-    /// Reset.
     void Reset() noexcept
     {
         ThisType temp;
@@ -261,6 +260,13 @@ public:
     void Reset(U* ptr) noexcept
     {
         ThisType temp(ptr);
+        this->Swap(temp);
+    }
+
+    /// Reset with another pointers.
+    void Reset(InterfaceType* ptr, RefCounted* refCounted) noexcept
+    {
+        ThisType temp(ptr, refCounted);
         this->Swap(temp);
     }
 

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
@@ -178,14 +178,14 @@ bool ShaderVariation::LoadByteCode(const ea::string& binaryShaderName)
     if (!cache->Exists(binaryShaderName))
         return false;
 
-    FileSystem* fileSystem = owner_->GetSubsystem<FileSystem>();
-    unsigned sourceTimeStamp = owner_->GetTimeStamp();
+    const FileSystem* fileSystem = owner_->GetSubsystem<FileSystem>();
+    const unsigned sourceTimeStamp = owner_->GetTimeStamp();
     // If source code is loaded from a package, its timestamp will be zero. Else check that binary is not older
     // than source
     if (sourceTimeStamp && fileSystem->GetLastModifiedTime(cache->GetResourceFileName(binaryShaderName)) < sourceTimeStamp)
         return false;
 
-    SharedPtr<File> file = cache->GetFile(binaryShaderName);
+    const AbstractFilePtr file = cache->GetFile(binaryShaderName);
     if (!file || file->ReadFileID() != "USHD")
     {
         URHO3D_LOGERROR(binaryShaderName + " is not a valid shader bytecode file");
@@ -455,7 +455,7 @@ void ShaderVariation::SaveByteCode(const ea::string& binaryShaderName)
     if (!fileSystem->DirExists(path))
         fileSystem->CreateDir(path);
 
-    SharedPtr<File> file(new File(owner_->GetContext(), fullName, FILE_WRITE));
+    const AbstractFilePtr file(MakeShared<File>(owner_->GetContext(), fullName, FILE_WRITE));
     if (!file->IsOpen())
         return;
 

--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -108,7 +108,7 @@ StringHash ParseTextureTypeXml(ResourceCache* cache, const ea::string& filename)
     if (!cache)
         return type;
 
-    SharedPtr<File> texXmlFile = cache->GetFile(filename, false);
+    AbstractFilePtr texXmlFile = cache->GetFile(filename, false);
     if (texXmlFile)
     {
         auto texXml = MakeShared<XMLFile>(cache->GetContext());

--- a/Source/Urho3D/Graphics/Shader.cpp
+++ b/Source/Urho3D/Graphics/Shader.cpp
@@ -306,7 +306,7 @@ void Shader::ProcessSource(ea::string& code, Deserializer& source)
             ea::string includeFileName = GetPath(source.GetName()) + line.substr(9).replaced("\"", "").trimmed();
 
             // Add included code or error directive
-            SharedPtr<File> includeFile = cache->GetFile(includeFileName);
+            AbstractFilePtr includeFile = cache->GetFile(includeFileName);
             if (includeFile)
                 ProcessSource(code, *includeFile);
             else

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -309,7 +309,7 @@ void StaticModel::ApplyMaterialList(const ea::string& fileName)
         useFileName = ReplaceExtension(model_->GetName(), ".txt");
 
     auto* cache = GetSubsystem<ResourceCache>();
-    SharedPtr<File> file = cache->GetFile(useFileName, false);
+    const AbstractFilePtr file = cache->GetFile(useFileName, false);
     if (!file)
         return;
 

--- a/Source/Urho3D/Graphics/Texture3D.cpp
+++ b/Source/Urho3D/Graphics/Texture3D.cpp
@@ -118,7 +118,7 @@ bool Texture3D::BeginLoad(Deserializer& source)
         if (colorlutTexPath.empty())
             name = texPath + name;
 
-        SharedPtr<File> file = GetSubsystem<ResourceCache>()->GetFile(name);
+        AbstractFilePtr file = GetSubsystem<ResourceCache>()->GetFile(name);
         loadImage_ = MakeShared<Image>(context_);
         if (!loadImage_->LoadColorLUT(*(file.Get())))
         {

--- a/Source/Urho3D/IO/AbstractFile.h
+++ b/Source/Urho3D/IO/AbstractFile.h
@@ -41,6 +41,15 @@ public:
     /// Change the file name. Used by the resource system.
     /// @property
     virtual void SetName(const ea::string& name) { name_ = name; }
+    /// Return whether is open.
+    /// @property
+    virtual bool IsOpen() const { return true; }
+    /// Return absolute file name in file system.
+    /// @property
+    virtual const ea::string& GetAbsoluteName() const { return name_; }
+    /// Close the file.
+    virtual void Close() {}
+
 #ifndef SWIG
     // A workaround for SWIG failing to generate bindings because both IAbstractFile and IDeserializer provide GetName() method. This is
     // fine because IAbstractFile inherits GetName() from IDeserializer anyway.
@@ -53,5 +62,7 @@ protected:
     /// File name.
     ea::string name_;
 };
+
+typedef SharedPtr<AbstractFile, RefCounted> AbstractFilePtr;
 
 }

--- a/Source/Urho3D/IO/File.cpp
+++ b/Source/Urho3D/IO/File.cpp
@@ -351,6 +351,11 @@ unsigned File::Write(const void* data, unsigned size)
     return size;
 }
 
+const ea::string& File::GetAbsoluteName() const
+{
+    return absoluteFileName_;
+}
+
 unsigned File::GetChecksum()
 {
     if (offset_ || checksum_)

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -83,7 +83,7 @@ public:
     unsigned Write(const void* data, unsigned size) override;
 
     /// Return absolute file name in file system.
-    const ea::string& GetAbsoluteName() const { return absoluteFileName_; }
+    const ea::string& GetAbsoluteName() const override;
 
     /// Return a checksum of the file contents using the SDBM hash algorithm.
     unsigned GetChecksum() override;
@@ -93,7 +93,7 @@ public:
     /// Open from within a package file. Return true if successful.
     bool Open(PackageFile* package, const ea::string& fileName);
     /// Close the file.
-    void Close();
+    void Close() override;
     /// Flush any buffered output to the file.
     void Flush();
 
@@ -103,7 +103,7 @@ public:
 
     /// Return whether is open.
     /// @property
-    bool IsOpen() const;
+    bool IsOpen() const override;
 
     /// Return the file handle.
     void* GetHandle() const { return handle_; }

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -136,7 +136,7 @@ int DoSystemCommand(const ea::string& commandLine, bool redirectToLog, Context* 
     // Capture the standard error stream
     if (!stderrFilename.empty())
     {
-        SharedPtr<File> errFile(new File(context, stderrFilename, FILE_READ));
+        const AbstractFilePtr errFile(MakeShared<File>(context, stderrFilename, FILE_READ));
         while (!errFile->IsEof())
         {
             unsigned numRead = errFile->Read(buffer, sizeof(buffer));
@@ -622,10 +622,10 @@ bool FileSystem::Copy(const ea::string& srcFileName, const ea::string& destFileN
         return false;
     }
 
-    SharedPtr<File> srcFile(new File(context_, srcFileName, FILE_READ));
+    const AbstractFilePtr srcFile(MakeShared<File>(context_, srcFileName, FILE_READ));
     if (!srcFile->IsOpen())
         return false;
-    SharedPtr<File> destFile(new File(context_, destFileName, FILE_WRITE));
+    const AbstractFilePtr destFile(MakeShared<File>(context_, destFileName, FILE_WRITE));
     if (!destFile->IsOpen())
         return false;
 

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -136,7 +136,7 @@ int DoSystemCommand(const ea::string& commandLine, bool redirectToLog, Context* 
     // Capture the standard error stream
     if (!stderrFilename.empty())
     {
-        const AbstractFilePtr errFile(MakeShared<File>(context, stderrFilename, FILE_READ));
+        auto errFile = MakeShared<File>(context, stderrFilename, FILE_READ);
         while (!errFile->IsEof())
         {
             unsigned numRead = errFile->Read(buffer, sizeof(buffer));
@@ -622,10 +622,10 @@ bool FileSystem::Copy(const ea::string& srcFileName, const ea::string& destFileN
         return false;
     }
 
-    const AbstractFilePtr srcFile(MakeShared<File>(context_, srcFileName, FILE_READ));
+    auto srcFile = MakeShared<File>(context_, srcFileName, FILE_READ);
     if (!srcFile->IsOpen())
         return false;
-    const AbstractFilePtr destFile(MakeShared<File>(context_, destFileName, FILE_WRITE));
+    auto destFile = MakeShared<File>(context_, destFileName, FILE_WRITE);
     if (!destFile->IsOpen())
         return false;
 

--- a/Source/Urho3D/IO/PackageFile.cpp
+++ b/Source/Urho3D/IO/PackageFile.cpp
@@ -53,7 +53,7 @@ PackageFile::~PackageFile() = default;
 
 bool PackageFile::Open(const ea::string& fileName, unsigned startOffset)
 {
-    SharedPtr<File> file(new File(context_, fileName));
+    const AbstractFilePtr file(MakeShared<File>(context_, fileName));
     if (!file->IsOpen())
         return false;
 

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -549,7 +549,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
                     }
 
                     // Try to open the file now
-                    SharedPtr<File> file(new File(context_, packageFullName));
+                    const AbstractFilePtr file(MakeShared<File>(context_, packageFullName));
                     if (!file->IsOpen())
                     {
                         URHO3D_LOGERROR("Failed to transmit package file " + name);
@@ -601,7 +601,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
             // If file has not yet been opened, try to open now. Prepend the checksum to the filename to allow multiple versions
             if (!download.file_)
             {
-                download.file_ = new File(context_,
+                download.file_ = MakeShared<File>(context_,
                     GetSubsystem<Network>()->GetPackageCacheDir() + ToStringHex(download.checksum_) + "_" + download.name_,
                     FILE_WRITE);
                 if (!download.file_->IsOpen())
@@ -614,7 +614,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
             // Write the fragment data to the proper index
             unsigned char buffer[PACKAGE_FRAGMENT_SIZE];
             unsigned index = msg.ReadUInt();
-            unsigned fragmentSize = msg.GetSize() - msg.GetPosition();
+            const unsigned fragmentSize = msg.GetSize() - msg.GetPosition();
 
             msg.Read(buffer, fragmentSize);
             download.file_->Seek(index * PACKAGE_FRAGMENT_SIZE);
@@ -1060,7 +1060,7 @@ void Connection::OnPackagesReady()
     {
         // Otherwise start the async loading process
         ea::string extension = GetExtension(sceneFileName_);
-        SharedPtr<File> file = GetSubsystem<ResourceCache>()->GetFile(sceneFileName_);
+        AbstractFilePtr file = GetSubsystem<ResourceCache>()->GetFile(sceneFileName_);
         bool success;
 
         if (extension == ".xml")

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -73,7 +73,7 @@ struct PackageDownload
     PackageDownload();
 
     /// Destination file.
-    SharedPtr<File> file_;
+    AbstractFilePtr file_;
     /// Already received fragments.
     ea::hash_set<unsigned> receivedFragments_;
     /// Package name.
@@ -93,7 +93,7 @@ struct PackageUpload
     PackageUpload();
 
     /// Source file.
-    SharedPtr<File> file_;
+    AbstractFilePtr file_;
     /// Current fragment index.
     unsigned fragment_;
     /// Total number of fragments.

--- a/Source/Urho3D/Resource/BackgroundLoader.cpp
+++ b/Source/Urho3D/Resource/BackgroundLoader.cpp
@@ -81,7 +81,7 @@ void BackgroundLoader::ThreadFunction()
             backgroundLoadMutex_.Release();
 
             bool success = false;
-            SharedPtr<File> file = owner_->GetFile(resource->GetName(), item.sendEventOnFailure_);
+            AbstractFilePtr file = owner_->GetFile(resource->GetName(), item.sendEventOnFailure_);
             if (file)
             {
                 resource->SetAsyncLoadState(ASYNC_LOADING);

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -151,7 +151,7 @@ public:
     void RemoveResourceRouter(ResourceRouter* router);
 
     /// Open and return a file from the resource load paths or from inside a package file. If not found, use a fallback search with absolute path. Return null if fails. Can be called from outside the main thread.
-    SharedPtr<File> GetFile(const ea::string& name, bool sendEventOnFailure = true);
+    AbstractFilePtr GetFile(const ea::string& name, bool sendEventOnFailure = true);
     /// Return a resource by type and name. Load if not loaded yet. Return null if not found or if fails, unless SetReturnFailedResources(true) has been called. Can be called only from the main thread.
     Resource* GetResource(StringHash type, const ea::string& name, bool sendEventOnFailure = true);
     /// Load a resource without storing it in the resource cache. Return null if not found or if fails. Can be called from outside the main thread if the resource itself is safe to load completely (it does not possess for example GPU data).
@@ -268,9 +268,9 @@ private:
     /// Handle begin frame event. Automatic resource reloads and the finalization of background loaded resources are processed here.
     void HandleBeginFrame(StringHash eventType, VariantMap& eventData);
     /// Search FileSystem for file.
-    File* SearchResourceDirs(const ea::string& name);
+    AbstractFilePtr SearchResourceDirs(const ea::string& name);
     /// Search resource packages for file.
-    File* SearchPackages(const ea::string& name);
+    AbstractFilePtr SearchPackages(const ea::string& name);
 
     /// Mutex for thread-safe access to the resource directories, resource packages and resource dependencies.
     mutable Mutex resourceMutex_;

--- a/Source/Urho3D/RmlUI/RmlFile.cpp
+++ b/Source/Urho3D/RmlUI/RmlFile.cpp
@@ -46,7 +46,7 @@ RmlFile::RmlFile(Urho3D::Context* context)
 Rml::FileHandle RmlFile::Open(const Rml::String& path)
 {
     ResourceCache* cache = context_->GetSubsystem<ResourceCache>();
-    SharedPtr<File> file(cache->GetFile(path));
+    AbstractFilePtr file(cache->GetFile(path));
     if (file != nullptr)
     {
         loadedFiles_.insert(GetAbsolutePath(cache->GetResourceFileName(path)));

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -334,7 +334,7 @@ bool Scene::SaveJSON(Serializer& dest, const ea::string& indentation) const
         return false;
 }
 
-bool Scene::LoadAsync(File* file, LoadMode mode)
+bool Scene::LoadAsync(AbstractFilePtr file, LoadMode mode)
 {
     if (!file)
     {
@@ -407,7 +407,7 @@ bool Scene::LoadAsync(File* file, LoadMode mode)
     return true;
 }
 
-bool Scene::LoadAsyncXML(File* file, LoadMode mode)
+bool Scene::LoadAsyncXML(AbstractFilePtr file, LoadMode mode)
 {
     if (!file)
     {
@@ -476,7 +476,7 @@ bool Scene::LoadAsyncXML(File* file, LoadMode mode)
     return true;
 }
 
-bool Scene::LoadAsyncJSON(File* file, LoadMode mode)
+bool Scene::LoadAsyncJSON(AbstractFilePtr file, LoadMode mode)
 {
     if (!file)
     {
@@ -1217,7 +1217,7 @@ void Scene::FinishSaving(Serializer* dest) const
     }
 }
 
-void Scene::PreloadResources(File* file, bool isSceneFile)
+void Scene::PreloadResources(AbstractFile* file, bool isSceneFile)
 {
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef URHO3D_THREADING

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -60,7 +60,7 @@ enum LoadMode
 struct AsyncProgress
 {
     /// File for binary mode.
-    SharedPtr<File> file_;
+    AbstractFilePtr file_;
     /// XML file for XML mode.
     SharedPtr<XMLFile> xmlFile_;
     /// JSON file for JSON mode.
@@ -149,11 +149,11 @@ public:
     /// Save to a JSON file. Return true if successful.
     bool SaveJSON(Serializer& dest, const ea::string& indentation = "\t") const;
     /// Load from a binary file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsync(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsync(AbstractFilePtr file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Load from an XML file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsyncXML(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsyncXML(AbstractFilePtr file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Load from a JSON file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsyncJSON(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsyncJSON(AbstractFilePtr file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Stop asynchronous loading.
     void StopAsyncLoading();
     /// Instantiate scene content from binary data. Return root node if successful.
@@ -300,7 +300,7 @@ private:
     /// Finish saving. Sets the scene filename and checksum.
     void FinishSaving(Serializer* dest) const;
     /// Preload resources from a binary scene or object prefab file.
-    void PreloadResources(File* file, bool isSceneFile);
+    void PreloadResources(AbstractFile* file, bool isSceneFile);
     /// Preload resources from an XML scene or object prefab file.
     void PreloadResourcesXML(const XMLElement& element);
     /// Preload resources from a JSON scene or object prefab file.

--- a/Source/Urho3D/Scene/Serializable.cpp
+++ b/Source/Urho3D/Scene/Serializable.cpp
@@ -357,7 +357,7 @@ bool Serializable::SaveJSON(JSONValue& dest) const
 
 bool Serializable::Load(const ea::string& resourceName)
 {
-    SharedPtr<File> file(GetSubsystem<ResourceCache>()->GetFile(resourceName, false));
+    AbstractFilePtr file(GetSubsystem<ResourceCache>()->GetFile(resourceName, false));
     if (file)
         return Load(*file);
     return false;

--- a/Source/Urho3D/UI/FontFaceBitmap.cpp
+++ b/Source/Urho3D/UI/FontFaceBitmap.cpp
@@ -100,7 +100,7 @@ bool FontFaceBitmap::Load(const unsigned char* fontData, unsigned fontDataSize, 
         ea::string textureFile = fontPath + pageElem.GetAttribute("file");
 
         // Load texture manually to allow controlling the alpha channel mode
-        SharedPtr<File> fontFile = resourceCache->GetFile(textureFile);
+        AbstractFilePtr fontFile = resourceCache->GetFile(textureFile);
         SharedPtr<Image> fontImage(MakeShared<Image>(context));
         if (!fontFile || !fontImage->Load(*fontFile))
         {

--- a/Source/Urho3D/UI/SplashScreen.cpp
+++ b/Source/Urho3D/UI/SplashScreen.cpp
@@ -248,7 +248,7 @@ bool SplashScreen::QueueSceneResourcesAsync(const ea::string& fileName)
 {
     auto* cache = GetSubsystem<ResourceCache>();
     scene_ = MakeShared<Scene>(context_);
-    SharedPtr<File> file = cache->GetFile(fileName);
+    AbstractFilePtr file = cache->GetFile(fileName);
     if (file)
     {
         ea::string extension = GetExtension(fileName);

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -80,7 +80,7 @@ char* _spUtil_readFile(const char* path, int* length)
         return 0;
 
     ResourceCache* cache = currentAnimationSet->GetSubsystem<ResourceCache>();
-    SharedPtr<File> file = cache->GetFile(path);
+    AbstractFilePtr file = cache->GetFile(path);
     if (!file)
         return 0;
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -598,7 +598,7 @@ void TmxFile2D::SetSpriteTextureEdgeOffset(float offset)
 SharedPtr<XMLFile> TmxFile2D::LoadTSXFile(const ea::string& source)
 {
     ea::string tsxFilePath = GetParentPath(GetName()) + source;
-    SharedPtr<File> tsxFile = GetSubsystem<ResourceCache>()->GetFile(tsxFilePath);
+    AbstractFilePtr tsxFile = GetSubsystem<ResourceCache>()->GetFile(tsxFilePath);
     SharedPtr<XMLFile> tsxXMLFile(MakeShared<XMLFile>(context_));
     if (!tsxFile || !tsxXMLFile->Load(*tsxFile))
     {


### PR DESCRIPTION
First step towards File refactoring. Having an AbstractFile everywhere allows us to split the File implementation into two or more distinct simple classes.