### PR TITLE
Fix regex expression that collapses =1 in config.

### DIFF
--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -533,7 +533,7 @@ list (REMOVE_DUPLICATES URHO3D_ENGINE_CONFIG)
 list (APPEND URHO3D_ENGINE_CONFIG "")   # For last item to be processed correctly.
 # Give defines without value a value "1".
 string (REPLACE ";" "=1;" URHO3D_ENGINE_CONFIG "${URHO3D_ENGINE_CONFIG}")                   # Append =1 to all defines
-string (REGEX REPLACE "([0-9]|>|\")=1" "\\1" URHO3D_ENGINE_CONFIG "${URHO3D_ENGINE_CONFIG}")   # Clear =1 from defines that already had a value
+string (REGEX REPLACE "(\=[0-9]+)+;" "\\1;" URHO3D_ENGINE_CONFIG "${URHO3D_ENGINE_CONFIG}")   # Clear =1 from defines that already had a value
 # Turn list into c++ preprocessor code
 string (REGEX REPLACE "([^=]+)=([^;]+);" "#ifndef \\1\n#   define \\1 \\2\n#endif\n" URHO3D_ENGINE_CONFIG "${URHO3D_ENGINE_CONFIG}")
 # This will be commented out line in the header.


### PR DESCRIPTION
Previous expression had issues with config names that ended in digits. More specifically, the `URHO3D_D3D11` config that ended in `1`. Which resulted in `URHO3D_D3D11` without the `=1` appended to it. Causing the next config name to be dumped around the initial config name. Example:
```cpp
// Engine configuration
#ifndef URHO3D_D3D11
URHO3D_DEBUG_ASSERT
#   define URHO3D_D3D11
URHO3D_DEBUG_ASSERT 1
#endif
#ifndef URHO3D_ENABLE_ALL
//...
```

From what I could test. The new expression was able to handle a wild array of cases. And when collapsing, only the last value is kept. Which happens to be the one appended manually. Example:
```cpp
TEST=2323=232=21;
```
Becomes:
```cpp
TEST=21;
```
Except in out case its `=1` mostly.