### PR TITLE
Less verbose and more robust config files

### DIFF
--- a/Source/Tests/IO/ConfigFile.cpp
+++ b/Source/Tests/IO/ConfigFile.cpp
@@ -77,14 +77,13 @@ TEST_CASE("Load malformed file returns false")
 
 TEST_CASE("Load config from file")
 {
-    MemoryBuffer buffer(R"({
-"Settings": [
+    MemoryBuffer buffer(R"([
     {
 		"key": "key0",
 		"type": "Int",
 		"value": 3
     }
-]})");
+])");
 
     auto context = Tests::GetOrCreateContext(Tests::CreateCompleteContext);
     auto* vfs = context->GetSubsystem<VirtualFileSystem>();
@@ -104,8 +103,7 @@ TEST_CASE("Load config file from JSON")
     auto context = Tests::GetOrCreateContext(Tests::CreateCompleteContext);
 
     JSONFile jsonFile(context);
-    MemoryBuffer buffer(R"({
-"Settings": [
+    MemoryBuffer buffer(R"([
     {
 		"key": "key0",
 		"type": "Int",
@@ -116,7 +114,7 @@ TEST_CASE("Load config file from JSON")
 		"type": "Int",
 		"value": 6
     }
-]})");
+])");
     CHECK(jsonFile.Load(buffer));
 
     ConfigFile configFile(context);
@@ -155,12 +153,10 @@ TEST_CASE("Load config file from XML")
 
     XMLFile xmlFile(context);
     MemoryBuffer buffer(R"(<?xml version="1.0"?>
-<Settings>
 	<Settings>
 		<Value key="key0" type="Int" value="3" />
 		<Value key="key2" type="Int" value="6" />
-	</Settings>
-</Settings>)");
+	</Settings>)");
     CHECK(xmlFile.Load(buffer));
 
     ConfigFile configFile(context);

--- a/Source/Urho3D/IO/ConfigFile.cpp
+++ b/Source/Urho3D/IO/ConfigFile.cpp
@@ -196,7 +196,6 @@ bool ConfigFileBase::Load(Deserializer& source)
     try
     {
         BinaryInputArchive archive(context_, source);
-        auto block = archive.OpenUnorderedBlock("Settings");
         SerializeInBlock(archive);
     }
     catch (std::exception ex)
@@ -210,16 +209,22 @@ bool ConfigFileBase::Load(Deserializer& source)
 bool ConfigFileBase::Save(Serializer& dest) const
 {
     BinaryOutputArchive archive(context_, dest);
-    auto block = archive.OpenUnorderedBlock("Settings");
     const_cast<ConfigFileBase*>(this)->SerializeInBlock(archive);
     return true;
 }
 
 bool ConfigFileBase::LoadXML(const XMLElement& xmlFile)
 {
-    XMLInputArchive archive(context_, xmlFile);
-    auto block = archive.OpenUnorderedBlock(xmlFile.GetName().c_str());
-    this->SerializeInBlock(archive);
+    try
+    {
+        XMLInputArchive archive(context_, xmlFile);
+        this->SerializeInBlock(archive);
+    }
+    catch (const ArchiveException& ex)
+    {
+        URHO3D_LOGERROR("{}", ex.what());
+        return false;
+    }
     return true;
 }
 
@@ -232,7 +237,6 @@ bool ConfigFileBase::SaveXML(XMLElement& xmlFile) const
     }
 
     XMLOutputArchive archive(context_, xmlFile);
-    auto block = archive.OpenUnorderedBlock(xmlFile.GetName().c_str());
     const_cast<ConfigFileBase*>(this)->SerializeInBlock(archive);
     return true;
 }
@@ -242,16 +246,22 @@ bool ConfigFileBase::LoadJSON(const JSONValue& source)
     if (source.IsNull())
         return false;
 
-    JSONInputArchive archive(context_, source);
-    auto block = archive.OpenUnorderedBlock("Settings");
-    this->SerializeInBlock(archive);
+    try
+    {
+        JSONInputArchive archive(context_, source);
+        this->SerializeInBlock(archive);
+    }
+    catch (const ArchiveException& ex)
+    {
+        URHO3D_LOGERROR("{}", ex.what());
+        return false;
+    }
     return true;
 }
 
 bool ConfigFileBase::SaveJSON(JSONValue& dest) const
 {
     JSONOutputArchive archive(context_, dest);
-    auto block = archive.OpenUnorderedBlock("Settings");
     const_cast<ConfigFileBase*>(this)->SerializeInBlock(archive);
     return true;
 }


### PR DESCRIPTION
Config file root element should be array.
If parsing config file throws it should return false and not crash the app.