### PR TITLE
Outline group .net fix

### DIFF
--- a/Source/Tests/CSharp/Graphics/OutlineGroupTests.cs
+++ b/Source/Tests/CSharp/Graphics/OutlineGroupTests.cs
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2023-2023 the rbfx project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Urho3DNet.Tests
+{
+    public class OutlineTests
+    {
+        [Fact]
+        public async Task AddAndRemoveDrawable()
+        {
+            await ApplicationRunner.RunAsync(app =>
+            {
+                using var outline = SharedPtr.MakeShared<OutlineGroup>(app.Context);
+                Assert.NotNull(outline.Ptr);
+                using var staticModel = SharedPtr.MakeShared<StaticModel>(app.Context);
+                Assert.False(outline.Ptr.HasDrawable(staticModel));
+                Assert.False(outline.Ptr.RemoveDrawable(staticModel));
+                Assert.True(outline.Ptr.AddDrawable(staticModel));
+                Assert.True(outline.Ptr.HasDrawable(staticModel));
+                Assert.False(outline.Ptr.AddDrawable(staticModel));
+                Assert.True(outline.Ptr.RemoveDrawable(staticModel));
+                Assert.False(outline.Ptr.HasDrawable(staticModel));
+            });
+        }
+    }
+}

--- a/Source/Tests/CSharp/Urho3DNet.Tests.csproj
+++ b/Source/Tests/CSharp/Urho3DNet.Tests.csproj
@@ -10,7 +10,7 @@
     <GeneratedCodePath>$(RBFX_BINARY_DIR)Source/Urho3D/</GeneratedCodePath>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="*.cs" />
+    <Compile Include="**/*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/Source/Urho3D/CSharp/Managed/Scene/Node.cs
+++ b/Source/Urho3D/CSharp/Managed/Scene/Node.cs
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+using System.ComponentModel;
+
 namespace Urho3DNet
 {
     public partial class Node
@@ -43,22 +45,32 @@ namespace Urho3DNet
         /// Get first occurrence of a component type
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <returns>Found component or null.</returns>
         public T GetComponent<T>() where T: Component
         {
             return (T)GetComponent(typeof(T).Name);
         }
 
         /// <summary>
-        /// get all components of a type
+        /// Get all components of a type
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <returns>List of found component or null.</returns>
         public ComponentList GetComponents<T>(bool recursive = false) where T: Component
         {
             ComponentList componentList = new ComponentList();
             GetComponents(componentList, typeof(T).Name, recursive);
             return componentList;
+        }
+
+        /// <summary>
+        /// Return component in parent node. If there are several, returns the first. May optional traverse up to the root node.
+        /// </summary>
+        /// <typeparam name="T">Type of the component.</typeparam>
+        /// <returns>Found component or null.</returns>
+        public T GetParentComponent<T>(bool fullTraversal = false) where T : Component
+        {
+            return (T)GetParentComponent(typeof(T).Name, fullTraversal);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Managed/Scene/Node.cs
+++ b/Source/Urho3D/CSharp/Managed/Scene/Node.cs
@@ -55,7 +55,7 @@ namespace Urho3DNet
         /// Get all components of a type
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <returns>List of found component or null.</returns>
+        /// <returns>List of found components.</returns>
         public ComponentList GetComponents<T>(bool recursive = false) where T: Component
         {
             ComponentList componentList = new ComponentList();

--- a/Source/Urho3D/CSharp/Swig/Urho3D.i
+++ b/Source/Urho3D/CSharp/Swig/Urho3D.i
@@ -702,6 +702,7 @@ public:
 %include "Urho3D/Graphics/Zone.h"
 %include "Urho3D/Graphics/Renderer.h"
 %include "Urho3D/Graphics/Graphics.h"
+%include "Urho3D/Graphics/OutlineGroup.h"
 
 // ------------------------------------- RenderPipeline -------------------------------------
 %include "generated/Urho3D/_pre_renderpipeline.i"

--- a/Source/Urho3D/Graphics/OutlineGroup.cpp
+++ b/Source/Urho3D/Graphics/OutlineGroup.cpp
@@ -149,14 +149,19 @@ void OutlineGroup::ClearDrawables()
     drawables_.clear();
 }
 
-void OutlineGroup::AddDrawable(Drawable* drawable)
+bool OutlineGroup::HasDrawable(Drawable* drawable) const
 {
-    drawables_.emplace(drawable);
+    return drawables_.contains(WeakPtr<Drawable>(drawable));
 }
 
-void OutlineGroup::RemoveDrawable(Drawable* drawable)
+bool OutlineGroup::AddDrawable(Drawable* drawable)
 {
-    drawables_.erase(WeakPtr<Drawable>(drawable));
+    return drawables_.emplace(drawable).second;
+}
+
+bool OutlineGroup::RemoveDrawable(Drawable* drawable)
+{
+    return drawables_.erase(WeakPtr<Drawable>(drawable)) > 0;
 }
 
 Material* OutlineGroup::GetOutlineMaterial(Material* referenceMaterial)

--- a/Source/Urho3D/Graphics/OutlineGroup.h
+++ b/Source/Urho3D/Graphics/OutlineGroup.h
@@ -63,8 +63,12 @@ public:
     bool HasDrawables() const { return !drawables_.empty(); }
     bool ContainsDrawable(Drawable* drawable) const { return drawables_.find_as(drawable) != drawables_.end(); }
     void ClearDrawables();
-    void AddDrawable(Drawable* drawable);
-    void RemoveDrawable(Drawable* drawable);
+    /// Check if Drawable is present in group.
+    bool HasDrawable(Drawable* drawable) const;
+    /// Add drawable. Returns true if drawable added.
+    bool AddDrawable(Drawable* drawable);
+    /// Remove drawable. Returns true if drawable was removed.
+    bool RemoveDrawable(Drawable* drawable);
     /// @}
 
 private:


### PR DESCRIPTION
- .net wrapper fixed
- add/remove should return true in case of success to track what components already present in the collection
- GetParentComponent generic variation
- .net unit test for OutlineGroup