### PR TITLE
Disable macro redefinition warning

### DIFF
--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -31,7 +31,14 @@
 #include "../Replica/NetworkId.h"
 #include "../Scene/Component.h"
 
+#if defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable : 4005)
+#endif
 #include <Bullet/LinearMath/btIDebugDraw.h>
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 
 #include <EASTL/optional.h>
 


### PR DESCRIPTION
Addresses the following warning:
```
ThirdParty\Bullet\Bullet\LinearMath\btScalar.h(133,1): warning C4005: 'BT_USE_SSE': macro redefinition
ThirdParty\Bullet\Bullet\LinearMath\btScalar.h(133,1): message : 'BT_USE_SSE' previously declared on the command line
```