### PR TITLE
Move WorkQueue to enkiTS

### DIFF
--- a/Source/Editor/Editor.cpp
+++ b/Source/Editor/Editor.cpp
@@ -272,7 +272,7 @@ void Editor::Start()
 void Editor::Stop()
 {
     auto workQueue = GetSubsystem<WorkQueue>();
-    workQueue->Complete(0);
+    workQueue->CompleteAll();
 
     CloseProject();
 
@@ -330,7 +330,7 @@ void Editor::Render()
         // Exit immediately if requested.
         if (exiting_)
         {
-            context_->GetSubsystem<WorkQueue>()->Complete(0);
+            context_->GetSubsystem<WorkQueue>()->CompleteAll();
             engine_->Exit();
         }
 
@@ -450,16 +450,20 @@ void Editor::Render()
     // Dialog for a warning when application is being closed with unsaved resources.
     if (exiting_)
     {
-        if (!context_->GetSubsystem<WorkQueue>()->IsCompleted(0))
+        auto workQueue = context_->GetSubsystem<WorkQueue>();
+        if (!workQueue->IsCompleted())
         {
-            ui::OpenPopup("Completing Tasks");
+            if (!numIncompleteTasks_)
+                numIncompleteTasks_ = workQueue->GetNumIncomplete();
+            const unsigned numProcessedTasks =
+                *numIncompleteTasks_ - ea::min(workQueue->GetNumIncomplete(), *numIncompleteTasks_);
 
+            ui::OpenPopup("Completing Tasks");
             if (ui::BeginPopupModal("Completing Tasks", nullptr, ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoResize |
                                                                  ImGuiWindowFlags_NoMove | ImGuiWindowFlags_Popup))
             {
                 ui::TextUnformatted("Some tasks are in progress and are being completed. Please wait.");
-                static float totalIncomplete = context_->GetSubsystem<WorkQueue>()->GetNumIncomplete(0);
-                ui::ProgressBar(100.f / totalIncomplete * Min(totalIncomplete - (float)context_->GetSubsystem<WorkQueue>()->GetNumIncomplete(0), totalIncomplete));
+                ui::ProgressBar(100.f * numProcessedTasks / *numIncompleteTasks_);
                 ui::EndPopup();
             }
         }
@@ -473,10 +477,13 @@ void Editor::Render()
         }
         else
         {
-            context_->GetSubsystem<WorkQueue>()->Complete(0);
+            context_->GetSubsystem<WorkQueue>()->CompleteAll();
             engine_->Exit();
         }
     }
+
+    if (!exiting_)
+        numIncompleteTasks_ = ea::nullopt;
 
     const ea::string title = GetWindowTitle();
     if (windowTitle_ != title)

--- a/Source/Editor/Editor.h
+++ b/Source/Editor/Editor.h
@@ -107,6 +107,8 @@ protected:
     ea::unordered_map<ea::string, SharedPtr<Texture2D>> projectPreviews_;
 
     bool showAbout_{};
+
+    ea::optional<unsigned> numIncompleteTasks_;
     /// @}
 };
 

--- a/Source/ThirdParty/CMakeLists.txt
+++ b/Source/ThirdParty/CMakeLists.txt
@@ -43,6 +43,10 @@ add_subdirectory(spdlog)
 add_subdirectory(SDL)
 add_subdirectory(ETCPACK)
 
+if (NOT WEB)
+    add_subdirectory(enkiTS)
+endif ()
+
 if (NOT MINI_URHO)
     add_subdirectory(tinygltf)
     if (URHO3D_TESTING)

--- a/Source/ThirdParty/enkiTS/.gitignore
+++ b/Source/ThirdParty/enkiTS/.gitignore
@@ -1,0 +1,4 @@
+.travis.yml
+.github/
+example/
+src/*_c.*

--- a/Source/ThirdParty/enkiTS/CMakeLists.txt
+++ b/Source/ThirdParty/enkiTS/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2023-2023 the rbfx project.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+project(enkiTS)
+
+file(GLOB_RECURSE SOURCE_FILES src/TaskScheduler.h src/TaskScheduler.cpp src/LockLessMultiReadPipe.h)
+
+add_library(enkiTS STATIC ${SOURCE_FILES})
+target_compile_definitions(enkiTS PUBLIC "ENKITS_TASK_PRIORITIES_NUM=5")
+target_include_directories(enkiTS SYSTEM
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+
+if (NOT URHO3D_MERGE_STATIC_LIBS)
+    install(TARGETS enkiTS EXPORT Urho3D ARCHIVE DESTINATION ${DEST_ARCHIVE_DIR_CONFIG})
+endif ()

--- a/Source/ThirdParty/enkiTS/License.txt
+++ b/Source/ThirdParty/enkiTS/License.txt
@@ -1,0 +1,17 @@
+Copyright (c) 2013 Doug Binks
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgement in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/Source/ThirdParty/enkiTS/README.md
+++ b/Source/ThirdParty/enkiTS/README.md
@@ -1,0 +1,387 @@
+Support development of enkiTS through [Github Sponsors](https://github.com/sponsors/dougbinks) or [Patreon](https://www.patreon.com/enkisoftware)
+
+[<img src="https://img.shields.io/static/v1?logo=github&label=Github&message=Sponsor&color=#ea4aaa" width="200"/>](https://github.com/sponsors/dougbinks)    [<img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" alt="Become a Patron" width="150"/>](https://www.patreon.com/enkisoftware)
+
+![enkiTS Logo](https://github.com/dougbinks/images/blob/master/enkiTS_logo_no_padding.png?raw=true)
+# enkiTS
+| [Master branch](https://github.com/dougbinks/enkiTS/) | [Dev branch](https://github.com/dougbinks/enkiTS/tree/dev) |
+| --- | --- |
+| [![Build Status for branch: master](https://travis-ci.org/dougbinks/enkiTS.svg?branch=master)](https://travis-ci.org/dougbinks/enkiTS) | [![Build Status for branch: dev](https://travis-ci.org/dougbinks/enkiTS.svg?branch=dev)](https://travis-ci.org/dougbinks/enkiTS) |
+
+## enki Task Scheduler
+
+A permissively licensed C and C++ Task Scheduler for creating parallel programs. Requires C++11 support.
+
+The primary goal of enkiTS is to help developers create programs which handle both data and task level parallelism to utilize the full performance of multicore CPUs, whilst being lightweight (only a small amount of code) and easy to use.
+
+* [C++ API via src/TaskScheduler.h](src/TaskScheduler.h)
+* [C API via src/TaskScheduler_c.h](src/TaskScheduler_c.h)
+
+enkiTS was developed for, and is used in [enkisoftware](http://www.enkisoftware.com/)'s Avoyd codebase.
+
+## Platforms
+
+- Windows, Linux, Mac OS, Android (should work on iOS) 
+- x64 & x86, ARM
+
+enkiTS is primarily developed on x64 and x86 Intel architectures on MS Windows, with well tested support for Linux and somewhat less frequently tested support on Mac OS and ARM Android.
+
+## Examples
+
+Several examples exist in  the [example folder](https://github.com/dougbinks/enkiTS/tree/master/example).
+
+For further examples, see https://github.com/dougbinks/enkiTSExamples
+
+## Building
+
+Building enkiTS is simple, just add the files in enkiTS/src to your build system (_c.* files can be ignored if you only need C++ interface), and add enkiTS/src to your include path. Unix / Linux builds will likely require the pthreads library.
+
+For C++
+
+  - Use `#include "TaskScheduler.h"`
+  - Add enkiTS/src to your include path
+  - Compile / Add to project: 
+    - `TaskScheduler.cpp`
+  - Unix / Linux builds will likely require the pthreads library.
+
+For C
+
+  - Use `#include "TaskScheduler_c.h"`
+  - Add enkiTS/src to your include path
+  - Compile / Add to project:
+    - `TaskScheduler.cpp`
+    - `TaskScheduler_c.cpp`
+  - Unix / Linux builds will likely require the pthreads library.
+
+For cmake, on Windows / Mac OS X / Linux with cmake installed, open a prompt in the enkiTS directory and:
+
+1. `mkdir build`
+1. `cd build`
+1. `cmake ..`
+1. either run `make all` or for Visual Studio open `enkiTS.sln`
+
+## Project Features
+
+1. *Lightweight* - enkiTS is designed to be lean so you can use it anywhere easily, and understand it.
+1. *Fast, then scalable* - enkiTS is designed for consumer devices first, so performance on a low number of threads is important, followed by scalability.
+1. *Braided parallelism* - enkiTS can issue tasks from another task as well as from the thread which created the Task System, and has a simple task interface for both data parallel and task parallelism.
+1. *Up-front Allocation friendly* - enkiTS is designed for zero allocations during scheduling.
+1. *Can pin tasks to a given thread* - enkiTS can schedule a task which will only be run on the specified thread.
+1. *Can set task priorities* - Up to 5 task priorities can be configured via define ENKITS_TASK_PRIORITIES_NUM (defaults to 3). Higher priority tasks are run before lower priority ones.
+1. *Can register external threads to use with enkiTS* - Can configure enkiTS with numExternalTaskThreads which can be registered to use with the enkiTS API.
+1. *Custom allocator API* - can configure enkiTS with custom allocators, see [example/CustomAllocator.cpp](example/CustomAllocator.cpp) and [example/CustomAllocator_c.c](example/CustomAllocator_c.c).
+1. *Dependencies* - can set dependendencies between tasks see [example/Dependencies.cpp](example/Dependencies.cpp) and [example/Dependencies_c.c](example/Dependencies_c.c).
+1. *Completion Actions* - can perform an action on task completion. This avoids the expensive action of adding the task to the scheduler, and can be used to safely delete a completed task. See [example/CompletionAction.cpp](example/CompletionAction.cpp) and [example/CompletionAction_c.c](example/CompletionAction_c.c)
+1. **NEW** *Can wait for pinned tasks* - Can wait for pinned tasks, useful for creating IO threads which do no other work. See [example/WaitForNewPinnedTasks.cpp](example/WaitForNewPinnedTasks.cpp) and [example/WaitForNewPinnedTasks_c.c](example/WaitForNewPinnedTasks_c.c).
+
+## Using enkiTS
+
+### C++ usage
+- full example in [example/ParallelSum.cpp](example/ParallelSum.cpp)
+- C example in [example/ParallelSum_c.c](example/ParallelSum_c.c)
+```C
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+// define a task set, can ignore range if we only do one thing
+struct ParallelTaskSet : enki::ITaskSet {
+    void ExecuteRange(  enki::TaskSetPartition range_, uint32_t threadnum_ ) override {
+        // do something here, can issue tasks with g_TS
+    }
+};
+
+int main(int argc, const char * argv[]) {
+    g_TS.Initialize();
+    ParallelTaskSet task; // default constructor has a set size of 1
+    g_TS.AddTaskSetToPipe( &task );
+
+    // wait for task set (running tasks if they exist)
+    // since we've just added it and it has no range we'll likely run it.
+    g_TS.WaitforTask( &task );
+    return 0;
+}
+```
+
+### C++ 11 lambda usage
+- full example in [example/LambdaTask.cpp](example/LambdaTask.cpp)
+```C
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+int main(int argc, const char * argv[]) {
+   g_TS.Initialize();
+
+   enki::TaskSet task( 1, []( enki::TaskSetPartition range_, uint32_t threadnum_  ) {
+         // do something here
+      }  );
+
+   g_TS.AddTaskSetToPipe( &task );
+   g_TS.WaitforTask( &task );
+   return 0;
+}
+```
+
+### Task priorities usage in C++
+- full example in [example/Priorities.cpp](example/Priorities.cpp)
+- C example in [example/Priorities_c.c](example/Priorities_c.c)
+```C
+// See full example in Priorities.cpp
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+struct ExampleTask : enki::ITaskSet
+{
+    ExampleTask( ) { m_SetSize = size_; }
+
+    void ExecuteRange(  enki::TaskSetPartition range_, uint32_t threadnum_ ) override {
+        // See full example in Priorities.cpp
+    }
+};
+
+
+// This example demonstrates how to run a long running task alongside tasks
+// which must complete as early as possible using priorities.
+int main(int argc, const char * argv[])
+{
+    g_TS.Initialize();
+
+    ExampleTask lowPriorityTask( 10 );
+    lowPriorityTask.m_Priority  = enki::TASK_PRIORITY_LOW;
+
+    ExampleTask highPriorityTask( 1 );
+    highPriorityTask.m_Priority = enki::TASK_PRIORITY_HIGH;
+
+    g_TS.AddTaskSetToPipe( &lowPriorityTask );
+    for( int task = 0; task < 10; ++task )
+    {
+        // run high priority tasks
+        g_TS.AddTaskSetToPipe( &highPriorityTask );
+
+        // wait for task but only run tasks of the same priority or higher on this thread
+        g_TS.WaitforTask( &highPriorityTask, highPriorityTask.m_Priority );
+    }
+    // wait for low priority task, run any tasks on this thread whilst waiting
+    g_TS.WaitforTask( &lowPriorityTask );
+
+    return 0;
+}
+```
+
+### Pinned Tasks usage in C++
+- full example in [example/PinnedTask.cpp](example/PinnedTask.cpp)
+- C example in [example/PinnedTask_c.c](example/PinnedTask_c.c)
+```C
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+// define a task set, can ignore range if we only do one thing
+struct PinnedTask : enki::IPinnedTask {
+    void Execute() override {
+      // do something here, can issue tasks with g_TS
+    }
+};
+
+int main(int argc, const char * argv[]) {
+    g_TS.Initialize();
+    PinnedTask task; //default constructor sets thread for pinned task to 0 (main thread)
+    g_TS.AddPinnedTask( &task );
+
+    // RunPinnedTasks must be called on main thread to run any pinned tasks for that thread.
+    // Tasking threads automatically do this in their task loop.
+    g_TS.RunPinnedTasks();
+
+    // wait for task set (running tasks if they exist)
+    // since we've just added it and it has no range we'll likely run it.
+    g_TS.WaitforTask( &task );
+    return 0;
+}
+```
+
+### Dependency usage in C++
+- full example in [example/Dependencies.cpp](example/Dependencies.cpp)
+- C example in [example/Dependencies_c.c](example/Dependencies_c.c)
+```C
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+// define a task set, can ignore range if we only do one thing
+struct TaskA : enki::ITaskSet {
+    void ExecuteRange(  enki::TaskSetPartition range_, uint32_t threadnum_ ) override {
+        // do something here, can issue tasks with g_TS
+    }
+};
+
+struct TaskB : enki::ITaskSet {
+    enki::Dependency m_Dependency;
+    void ExecuteRange(  enki::TaskSetPartition range_, uint32_t threadnum_ ) override {
+        // do something here, can issue tasks with g_TS
+    }
+};
+
+int main(int argc, const char * argv[]) {
+    g_TS.Initialize();
+    
+    // set dependencies once (can set more than one if needed).
+    TaskA taskA;
+    TaskB taskB;
+    taskB.SetDependency( taskB.m_Dependency, &taskA );
+
+    g_TS.AddTaskSetToPipe( &taskA ); // add first task
+    g_TS.WaitforTask( &taskB );      // wait for last
+    return 0;
+}
+```
+
+### External task thread usage in C++
+- full example in [example/ExternalTaskThread.cpp](example/ExternalTaskThread.cpp)
+- C example in [example/ExternalTaskThread_c.c](example/ExternalTaskThread_c.c)
+```C
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+struct ParallelTaskSet : ITaskSet
+{
+    void ExecuteRange(  enki::TaskSetPartition range_, uint32_t threadnum_ ) override {
+        // Do something
+    }
+};
+
+void threadFunction()
+{
+    g_TS.RegisterExternalTaskThread();
+
+    // sleep for a while instead of doing something such as file IO
+    std::this_thread::sleep_for( std::chrono::milliseconds( num_ * 100 ) );
+
+    ParallelTaskSet task;
+    g_TS.AddTaskSetToPipe( &task );
+    g_TS.WaitforTask( &task);
+
+    g_TS.DeRegisterExternalTaskThread();
+}
+
+int main(int argc, const char * argv[])
+{
+    enki::TaskSchedulerConfig config;
+    config.numExternalTaskThreads = 1; // we have one extra external thread
+
+    g_TS.Initialize( config );
+
+    std::thread exampleThread( threadFunction );
+
+    exampleThread.join();
+
+    return 0;
+}
+```
+
+### WaitForPinnedTasks thread usage in C++ (useful for IO threads)
+- full example in [example/WaitForNewPinnedTasks.cpp](example/WaitForNewPinnedTasks.cpp)
+- C example in [example/WaitForNewPinnedTasks_c.c](example/WaitForNewPinnedTasks_c.c)
+```C++
+#include "TaskScheduler.h"
+
+enki::TaskScheduler g_TS;
+
+struct RunPinnedTaskLoopTask : enki::IPinnedTask
+{
+    void Execute() override
+    {
+        while( g_TS.GetIsRunning() )
+        {
+            g_TS.WaitForNewPinnedTasks(); // this thread will 'sleep' until there are new pinned tasks
+            g_TS.RunPinnedTasks();
+        }
+    }
+};
+
+struct PretendDoFileIO : enki::IPinnedTask
+{
+    void Execute() override
+    {
+        // Do file IO
+    }
+};
+
+int main(int argc, const char * argv[])
+{
+    enki::TaskSchedulerConfig config;
+
+    // In this example we create more threads than the hardware can run,
+    // because the IO thread will spend most of it's time idle or blocked
+    // and therefore not scheduled for CPU time by the OS
+    config.numTaskThreadsToCreate += 1;
+
+    g_TS.Initialize( config );
+
+    // in this example we place our IO threads at the end
+    RunPinnedTaskLoopTask runPinnedTaskLoopTasks;
+    runPinnedTaskLoopTasks.threadNum = g_TS.GetNumTaskThreads() - 1;
+    g_TS.AddPinnedTask( &runPinnedTaskLoopTasks );
+
+    // Send pretend file IO task to external thread FILE_IO
+    PretendDoFileIO pretendDoFileIO;
+    pretendDoFileIO.threadNum = runPinnedTaskLoopTasks.threadNum;
+    g_TS.AddPinnedTask( &pretendDoFileIO );
+
+    // ensure runPinnedTaskLoopTasks complete by explicitly calling shutdown
+    g_TS.WaitforAllAndShutdown();
+
+    return 0;
+}
+```
+
+
+## Bindings
+
+- C# [EnkiTasks C#](https://github.com/nxrighthere/EnkiTasks-CSharp)
+
+## Deprecated
+
+[The C++98 compatible branch](https://github.com/dougbinks/enkiTS/tree/C++98) has been deprecated as I'm not aware of anyone needing it.
+
+The user thread versions are no longer being maintained as they are no longer in use. Similar functionality can be obtained with the externalTaskThreads
+* [User thread version  on Branch UserThread](https://github.com/dougbinks/enkiTS/tree/UserThread) for running enkiTS on other tasking / threading systems, so it can be used as in other engines as well as standalone for example.
+* [C++ 11 version of user threads on Branch UserThread_C++11](https://github.com/dougbinks/enkiTS/tree/UserThread_C++11)
+
+## Projects using enkiTS
+
+### [Avoyd](https://www.avoyd.com)
+Avoyd is an abstract 6 degrees of freedom voxel game. enkiTS was developed for use in our [in-house engine powering Avoyd](https://www.enkisoftware.com/faq#engine). 
+
+![Avoyd screenshot](https://github.com/juliettef/Media/blob/main/Avoyd_2019-06-22_enkiTS_microprofile.jpg?raw=true)
+
+### [Imogen](https://github.com/CedricGuillemet/Imogen)
+GPU/CPU Texture Generator
+
+![Imogen screenshot](https://camo.githubusercontent.com/28347bc0c1627aa4f289e1b2b769afcb3a5de370/68747470733a2f2f692e696d6775722e636f6d2f7351664f3542722e706e67)
+
+### [ToyPathRacer](https://github.com/aras-p/ToyPathTracer)
+Aras Pranckevičius' code for his series on [Daily Path Tracer experiments with various languages](https://aras-p.info/blog/2018/03/28/Daily-Pathtracer-Part-0-Intro/).
+
+![ToyPathTracer screenshot](https://github.com/aras-p/ToyPathTracer/blob/main/Shots/screenshot.jpg?raw=true).
+
+## License (zlib)
+
+Copyright (c) 2013-2020 Doug Binks
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgement in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/Source/ThirdParty/enkiTS/src/LockLessMultiReadPipe.h
+++ b/Source/ThirdParty/enkiTS/src/LockLessMultiReadPipe.h
@@ -1,0 +1,283 @@
+// Copyright (c) 2013 Doug Binks
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgement in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+#include <stdint.h>
+#include <atomic>
+#include <string.h>
+
+#ifndef ENKI_ASSERT
+#include <assert.h>
+#define ENKI_ASSERT(x) assert(x)
+#endif
+
+namespace enki
+{
+    // LockLessMultiReadPipe - Single writer, multiple reader thread safe pipe using (semi) lockless programming
+    // Readers can only read from the back of the pipe
+    // The single writer can write to the front of the pipe, and read from both ends (a writer can be a reader)
+    // for many of the principles used here, see http://msdn.microsoft.com/en-us/library/windows/desktop/ee418650(v=vs.85).aspx
+    // Note: using log2 sizes so we do not need to clamp (multi-operation)
+    // T is the contained type
+    // Note this is not true lockless as the use of flags as a form of lock state.
+    template<uint8_t cSizeLog2, typename T> class LockLessMultiReadPipe
+    {
+    public:
+        LockLessMultiReadPipe();
+        ~LockLessMultiReadPipe() {}
+
+        // ReaderTryReadBack returns false if we were unable to read
+        // This is thread safe for both multiple readers and the writer
+        bool ReaderTryReadBack(   T* pOut );
+
+        // WriterTryReadFront returns false if we were unable to read
+        // This is thread safe for the single writer, but should not be called by readers
+        bool WriterTryReadFront(  T* pOut );
+
+        // WriterTryWriteFront returns false if we were unable to write
+        // This is thread safe for the single writer, but should not be called by readers
+        bool WriterTryWriteFront( const T& in );
+
+        // IsPipeEmpty() is a utility function, not intended for general use
+        // Should only be used very prudently.
+        bool IsPipeEmpty() const
+        {
+            return 0 == m_WriteIndex.load( std::memory_order_relaxed ) - m_ReadCount.load( std::memory_order_relaxed );
+        }
+
+        void Clear()
+        {
+            m_WriteIndex = 0;
+            m_ReadIndex = 0;
+            m_ReadCount = 0;
+            memset( (void*)m_Flags, 0, sizeof( m_Flags ) );
+        }
+
+    private:
+        const static uint32_t           ms_cSize        = ( 1 << cSizeLog2 );
+        const static uint32_t           ms_cIndexMask   = ms_cSize - 1;
+        const static uint32_t           FLAG_INVALID    = 0xFFFFFFFF; // 32bit for CAS
+        const static uint32_t           FLAG_CAN_WRITE  = 0x00000000; // 32bit for CAS
+        const static uint32_t           FLAG_CAN_READ   = 0x11111111; // 32bit for CAS
+
+        T                               m_Buffer[ ms_cSize ];
+
+        // read and write indexes allow fast access to the pipe, but actual access
+        // controlled by the access flags. 
+        std::atomic<uint32_t>            m_WriteIndex;
+        std::atomic<uint32_t>            m_ReadCount;
+        std::atomic<uint32_t>            m_Flags[  ms_cSize ];
+        std::atomic<uint32_t>            m_ReadIndex;
+    };
+
+    template<uint8_t cSizeLog2, typename T> inline
+        LockLessMultiReadPipe<cSizeLog2,T>::LockLessMultiReadPipe()
+        : m_WriteIndex(0)
+        , m_ReadCount(0)
+        , m_ReadIndex(0)
+    {
+        ENKI_ASSERT( cSizeLog2 < 32 );
+        memset( (void*)m_Flags, 0, sizeof( m_Flags ) );
+    }
+
+    template<uint8_t cSizeLog2, typename T> inline
+        bool LockLessMultiReadPipe<cSizeLog2,T>::ReaderTryReadBack(   T* pOut )
+    {
+
+        uint32_t actualReadIndex;
+        uint32_t readCount  = m_ReadCount.load( std::memory_order_relaxed );
+
+        // We get hold of read index for consistency
+        // and do first pass starting at read count
+        uint32_t readIndexToUse  = readCount;
+        while(true)
+        {
+
+            uint32_t writeIndex = m_WriteIndex.load( std::memory_order_relaxed );
+            // power of two sizes ensures we can use a simple calc without modulus
+            uint32_t numInPipe = writeIndex - readCount;
+            if( 0 == numInPipe )
+            {
+                return false;
+            }
+            if( readIndexToUse >= writeIndex )
+            {
+                readIndexToUse = m_ReadIndex.load( std::memory_order_relaxed );
+            }
+
+            // power of two sizes ensures we can perform AND for a modulus
+            actualReadIndex    = readIndexToUse & ms_cIndexMask;
+
+            // Multiple potential readers mean we should check if the data is valid,
+            // using an atomic compare exchange
+            uint32_t previous = FLAG_CAN_READ;
+            bool bSuccess = m_Flags[  actualReadIndex ].compare_exchange_strong( previous, FLAG_INVALID, std::memory_order_acq_rel, std::memory_order_relaxed );
+            if( bSuccess )
+            {
+                break;
+            }
+            ++readIndexToUse;
+
+            // Update read count
+            readCount  = m_ReadCount.load( std::memory_order_relaxed );
+        }
+
+        // we update the read index using an atomic add, as we've only read one piece of data.
+        // this ensure consistency of the read index, and the above loop ensures readers
+        // only read from unread data
+        m_ReadCount.fetch_add(1, std::memory_order_relaxed );
+
+        // now read data, ensuring we do so after above reads & CAS
+        *pOut = m_Buffer[ actualReadIndex ];
+
+        m_Flags[  actualReadIndex ].store( FLAG_CAN_WRITE, std::memory_order_release );
+
+        return true;
+    }
+
+    template<uint8_t cSizeLog2, typename T> inline
+        bool LockLessMultiReadPipe<cSizeLog2,T>::WriterTryReadFront(  T* pOut )
+    {
+        uint32_t writeIndex = m_WriteIndex.load( std::memory_order_relaxed );
+        uint32_t frontReadIndex  = writeIndex;
+
+        // Multiple potential readers mean we should check if the data is valid,
+        // using an atomic compare exchange - which acts as a form of lock (so not quite lockless really).
+        uint32_t actualReadIndex    = 0;
+        while(true)
+        {
+            uint32_t readCount  = m_ReadCount.load( std::memory_order_relaxed );
+            // power of two sizes ensures we can use a simple calc without modulus
+            uint32_t numInPipe = writeIndex - readCount;
+            if( 0 == numInPipe )
+            {
+                m_ReadIndex.store( readCount, std::memory_order_release );
+                return false;
+            }
+            --frontReadIndex;
+            actualReadIndex    = frontReadIndex & ms_cIndexMask;
+            uint32_t previous = FLAG_CAN_READ;
+            bool success = m_Flags[  actualReadIndex ].compare_exchange_strong( previous, FLAG_INVALID, std::memory_order_acq_rel, std::memory_order_relaxed );
+            if( success )
+            {
+                break;
+            }
+            else if( m_ReadIndex.load( std::memory_order_acquire ) >= frontReadIndex  )
+            {
+                return false;
+            }
+        }
+
+        // now read data, ensuring we do so after above reads & CAS
+        *pOut = m_Buffer[ actualReadIndex ];
+
+        m_Flags[  actualReadIndex ].store( FLAG_CAN_WRITE, std::memory_order_relaxed );
+
+        m_WriteIndex.store(writeIndex-1, std::memory_order_relaxed);
+        return true;
+    }
+
+
+    template<uint8_t cSizeLog2, typename T> inline
+        bool LockLessMultiReadPipe<cSizeLog2,T>::WriterTryWriteFront( const T& in )
+    {
+        // The writer 'owns' the write index, and readers can only reduce
+        // the amount of data in the pipe.
+        // We get hold of both values for consistency and to reduce false sharing
+        // impacting more than one access
+        uint32_t writeIndex = m_WriteIndex;
+
+        // power of two sizes ensures we can perform AND for a modulus
+        uint32_t actualWriteIndex    = writeIndex & ms_cIndexMask;
+
+        // a reader may still be reading this item, as there are multiple readers
+        if( m_Flags[ actualWriteIndex ].load(std::memory_order_acquire)  != FLAG_CAN_WRITE ) 
+        {
+            return false; // still being read, so have caught up with tail. 
+        }
+
+        // as we are the only writer we can update the data without atomics
+        //  whilst the write index has not been updated
+        m_Buffer[ actualWriteIndex ] = in;
+        m_Flags[  actualWriteIndex ].store( FLAG_CAN_READ, std::memory_order_release );
+
+        m_WriteIndex.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    }
+
+
+    // Lockless multiwriter intrusive list
+    // Type T must implement T* volatile pNext;
+    template<typename T> class  LocklessMultiWriteIntrusiveList
+    {
+
+        std::atomic<T*> pHead;
+        T               tail;
+    public:
+        LocklessMultiWriteIntrusiveList() : pHead( &tail )
+        {
+            tail.pNext = NULL;
+        }
+
+        bool IsListEmpty() const
+        {
+            return pHead == &tail;
+        }
+
+        // Add - safe to perform from any thread
+        void WriterWriteFront( T* pNode_ )
+        {
+            ENKI_ASSERT( pNode_ );
+            pNode_->pNext = NULL;
+            T* pPrev = pHead.exchange( pNode_ );
+            pPrev->pNext = pNode_;
+        }
+
+        // Remove - only thread safe for owner
+        T* ReaderReadBack()
+        {
+            T* pTailPlus1 = tail.pNext;
+            if( pTailPlus1 )
+            {
+                T* pTailPlus2 = pTailPlus1->pNext;
+                if( pTailPlus2 )
+                {
+                    //not head
+                    tail.pNext = pTailPlus2;
+                }
+                else
+                {
+                    tail.pNext = NULL;
+                    T* pCompare = pTailPlus1; // we need preserve pTailPlus1 as compare will alter it on failure
+                    // pTailPlus1 is the head, attempt swap with tail
+                    if( !pHead.compare_exchange_strong( pCompare, &tail ) )
+                    {
+                        // pCompare receives the revised pHead on failure.
+                        // pTailPlus1 is no longer the head, so pTailPlus1->pNext should be non NULL
+                        while( (T*)NULL == pTailPlus1->pNext ) {;} // wait for pNext to be updated as head may have just changed.
+                        tail.pNext = pTailPlus1->pNext.load();
+                        pTailPlus1->pNext = NULL;
+                    }
+                }
+            }
+            return pTailPlus1;
+        }
+    };
+
+}

--- a/Source/ThirdParty/enkiTS/src/TaskScheduler.cpp
+++ b/Source/ThirdParty/enkiTS/src/TaskScheduler.cpp
@@ -1,0 +1,1528 @@
+// Copyright (c) 2013 Doug Binks
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgement in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+#include "TaskScheduler.h"
+#include "LockLessMultiReadPipe.h"
+
+#include <algorithm>
+
+#if defined __i386__ || defined __x86_64__
+#include "x86intrin.h"
+#elif defined _WIN32
+#include <intrin.h>
+#endif
+
+using namespace enki;
+
+#if defined(ENKI_CUSTOM_ALLOC_FILE_AND_LINE)
+#define ENKI_FILE_AND_LINE __FILE__, __LINE__
+#else
+namespace
+{
+    const char* gc_File    = "";
+    const uint32_t gc_Line = 0;
+}
+#define ENKI_FILE_AND_LINE  gc_File, gc_Line
+#endif
+
+
+#ifdef _WIN64
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include "Windows.h"
+#endif
+
+uint32_t enki::GetNumHardwareThreads()
+{
+#ifdef _WIN64
+    return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+#else
+    return std::thread::hardware_concurrency();
+#endif
+}
+
+namespace enki
+{
+    static const int32_t  gc_TaskStartCount          = 2;
+    static const int32_t  gc_TaskAlmostCompleteCount = 1; // GetIsComplete() will return false, but execution is done and about to complete
+    static const uint32_t gc_PipeSizeLog2            = 8;
+    static const uint32_t gc_SpinCount               = 10;
+    static const uint32_t gc_SpinBackOffMulitplier   = 100;
+    static const uint32_t gc_MaxNumInitialPartitions = 8;
+    static const uint32_t gc_MaxStolenPartitions     = 1 << gc_PipeSizeLog2;
+    static const uint32_t gc_CacheLineSize           = 64;
+    // awaiting std::hardware_constructive_interference_size
+};
+
+// thread_local not well supported yet by C++11 compilers.
+#ifdef _MSC_VER
+    #if _MSC_VER <= 1800
+        #define thread_local __declspec(thread)
+    #endif
+#elif __APPLE__
+        // Apple thread_local currently not implemented despite it being in Clang.
+        #define thread_local __thread
+#endif
+
+
+// each software thread gets it's own copy of gtl_threadNum, so this is safe to use as a static variable
+static thread_local uint32_t                             gtl_threadNum       = 0;
+
+namespace enki 
+{
+    struct SubTaskSet
+    {
+        ITaskSet*           pTask;
+        TaskSetPartition    partition;
+    };
+
+    // we derive class TaskPipe rather than typedef to get forward declaration working easily
+    class TaskPipe : public LockLessMultiReadPipe<gc_PipeSizeLog2,enki::SubTaskSet> {};
+
+    enum ThreadState : int32_t
+    {
+        ENKI_THREAD_STATE_NONE,                  // shouldn't get this value
+        ENKI_THREAD_STATE_NOT_LAUNCHED,          // for debug purposes - indicates enki task thread not yet launched
+        ENKI_THREAD_STATE_RUNNING,
+        ENKI_THREAD_STATE_PRIMARY_REGISTERED,    // primary thread is the one enkiTS was initialized on
+        ENKI_THREAD_STATE_EXTERNAL_REGISTERED,
+        ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED,
+        ENKI_THREAD_STATE_WAIT_TASK_COMPLETION,
+        ENKI_THREAD_STATE_WAIT_NEW_TASKS,
+        ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS,
+        ENKI_THREAD_STATE_STOPPED,
+    };
+
+    struct ThreadArgs
+    {
+        uint32_t                 threadNum;
+        TaskScheduler*           pTaskScheduler;
+    };
+
+    struct alignas(enki::gc_CacheLineSize) ThreadDataStore 
+    {
+        semaphoreid_t*           pWaitNewPinnedTaskSemaphore = nullptr;
+        std::atomic<ThreadState> threadState = { ENKI_THREAD_STATE_NONE };
+        uint32_t                 rndSeed = 0;
+        char prevent_false_Share[ enki::gc_CacheLineSize - sizeof(std::atomic<ThreadState>) - sizeof(semaphoreid_t*) - sizeof( uint32_t ) ]; // required to prevent alignment padding warning
+    };
+    constexpr size_t SIZEOFTHREADDATASTORE = sizeof( ThreadDataStore ); // for easier inspection
+    static_assert( SIZEOFTHREADDATASTORE == enki::gc_CacheLineSize, "ThreadDataStore may exhibit false sharing" );
+
+    class PinnedTaskList : public LocklessMultiWriteIntrusiveList<IPinnedTask> {};
+
+    semaphoreid_t* SemaphoreCreate();
+    void SemaphoreDelete( semaphoreid_t* pSemaphore_ );
+    void SemaphoreWait(   semaphoreid_t& semaphoreid );
+    void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting );
+}
+
+namespace
+{
+    SubTaskSet SplitTask( SubTaskSet& subTask_, uint32_t rangeToSplit_ )
+    {
+        SubTaskSet splitTask = subTask_;
+        uint32_t rangeLeft = subTask_.partition.end - subTask_.partition.start;
+        rangeToSplit_ = std::min( rangeToSplit_, rangeLeft );
+        splitTask.partition.end = subTask_.partition.start + rangeToSplit_;
+        subTask_.partition.start = splitTask.partition.end;
+        return splitTask;
+    }
+
+    #if ( defined _WIN32 && ( defined _M_IX86  || defined _M_X64 ) ) || ( defined __i386__ || defined __x86_64__ )
+    // Note: see https://software.intel.com/en-us/articles/a-common-construct-to-avoid-the-contention-of-threads-architecture-agnostic-spin-wait-loops
+    static void SpinWait( uint32_t spinCount_ )
+    {
+        uint64_t end = __rdtsc() + spinCount_;
+        while( __rdtsc() < end )
+        {
+            _mm_pause();
+        }        
+    }
+    #else
+    static void SpinWait( uint32_t spinCount_ )
+    {
+        while( spinCount_ )
+        {
+            // TODO: may have NOP or yield equiv
+            --spinCount_;
+        }        
+    }
+    #endif
+}
+
+static void SafeCallback( ProfilerCallbackFunc func_, uint32_t threadnum_ )
+{
+    if( func_ != nullptr )
+    {
+        func_( threadnum_ );
+    }
+}
+
+   
+ENKITS_API void* enki::DefaultAllocFunc( size_t align_, size_t size_, void* userData_, const char* file_, int line_ )
+{ 
+    (void)userData_; (void)file_; (void)line_;
+    void* pRet;
+#ifdef _WIN32
+    pRet = (void*)_aligned_malloc( size_, align_ );
+#else
+    pRet = nullptr;
+    if( align_ <= size_ && align_ <= alignof(int64_t) )
+    {
+        // no need for alignment, use malloc
+        pRet = malloc( size_ );
+    }
+    else
+    {
+        int retval = posix_memalign( &pRet, align_, size_ );
+        (void)retval;	//unused
+    }
+#endif
+    return pRet;
+};
+
+ENKITS_API void  enki::DefaultFreeFunc(  void* ptr_,   size_t size_, void* userData_, const char* file_, int line_ )
+{
+     (void)size_; (void)userData_; (void)file_; (void)line_;
+#ifdef _WIN32
+    _aligned_free( ptr_ );
+#else
+    free( ptr_ );
+#endif
+};
+
+bool TaskScheduler::RegisterExternalTaskThread()
+{
+    bool bRegistered = false;
+    while( !bRegistered && m_NumExternalTaskThreadsRegistered < (int32_t)m_Config.numExternalTaskThreads  )
+    {
+        for(uint32_t thread = GetNumFirstExternalTaskThread(); thread < GetNumFirstExternalTaskThread() + m_Config.numExternalTaskThreads; ++thread )
+        {
+            ThreadState threadStateExpected = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
+            if( m_pThreadDataStore[thread].threadState.compare_exchange_strong(
+                threadStateExpected, ENKI_THREAD_STATE_EXTERNAL_REGISTERED ) )
+            {
+                ++m_NumExternalTaskThreadsRegistered;
+                gtl_threadNum = thread;
+                bRegistered = true;
+                break;
+            }
+        }
+    }
+    return bRegistered;
+}
+
+bool TaskScheduler::RegisterExternalTaskThread( uint32_t threadNumToRegister_ )
+{
+    ENKI_ASSERT( threadNumToRegister_ >= GetNumFirstExternalTaskThread() );
+    ENKI_ASSERT( threadNumToRegister_ < ( GetNumFirstExternalTaskThread() + m_Config.numExternalTaskThreads ) );
+    ThreadState threadStateExpected = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
+    if( m_pThreadDataStore[threadNumToRegister_].threadState.compare_exchange_strong(
+        threadStateExpected, ENKI_THREAD_STATE_EXTERNAL_REGISTERED ) )
+    {
+        ++m_NumExternalTaskThreadsRegistered;
+        gtl_threadNum = threadNumToRegister_;
+        return true;
+    }
+    return false;
+}
+
+
+void TaskScheduler::DeRegisterExternalTaskThread()
+{
+    ENKI_ASSERT( gtl_threadNum );
+    ThreadState threadState = m_pThreadDataStore[gtl_threadNum].threadState.load( std::memory_order_acquire );
+    ENKI_ASSERT( threadState == ENKI_THREAD_STATE_EXTERNAL_REGISTERED );
+    if( threadState == ENKI_THREAD_STATE_EXTERNAL_REGISTERED )
+    {
+        --m_NumExternalTaskThreadsRegistered;
+        m_pThreadDataStore[gtl_threadNum].threadState.store( ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED, std::memory_order_release );
+        gtl_threadNum = 0;
+    }
+}
+
+uint32_t TaskScheduler::GetNumRegisteredExternalTaskThreads()
+{
+    return m_NumExternalTaskThreadsRegistered;
+}
+
+void TaskScheduler::TaskingThreadFunction( const ThreadArgs& args_ )
+{
+    uint32_t threadNum  = args_.threadNum;
+    TaskScheduler*  pTS = args_.pTaskScheduler;
+    gtl_threadNum       = threadNum;
+
+    pTS->m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_release );
+    SafeCallback( pTS->m_Config.profilerCallbacks.threadStart, threadNum );
+
+    uint32_t spinCount = 0;
+    uint32_t hintPipeToCheck_io = threadNum + 1;    // does not need to be clamped.
+    while( pTS->GetIsRunning() )
+    {
+        if( !pTS->TryRunTask( threadNum, hintPipeToCheck_io ) )
+        {
+            // no tasks, will spin then wait
+            ++spinCount;
+            if( spinCount > gc_SpinCount )
+            {
+                pTS->WaitForNewTasks( threadNum );
+            }
+            else
+            {
+                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+                SpinWait( spinBackoffCount );
+            }
+        }
+        else
+        {
+            spinCount = 0; // have run a task so reset spin count.
+        }
+    }
+
+    pTS->m_NumInternalTaskThreadsRunning.fetch_sub( 1, std::memory_order_release );
+    pTS->m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_STOPPED, std::memory_order_release );
+    SafeCallback( pTS->m_Config.profilerCallbacks.threadStop, threadNum );
+    return;
+
+}
+
+
+void TaskScheduler::StartThreads()
+{
+    if( m_bHaveThreads )
+    {
+        return;
+    }
+
+    m_NumThreads = m_Config.numTaskThreadsToCreate + m_Config.numExternalTaskThreads + 1;
+
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        m_pPipesPerThread[ priority ]          = NewArray<TaskPipe>( m_NumThreads, ENKI_FILE_AND_LINE );
+        m_pPinnedTaskListPerThread[ priority ] = NewArray<PinnedTaskList>( m_NumThreads, ENKI_FILE_AND_LINE );
+    }
+
+    m_pNewTaskSemaphore      = SemaphoreNew();
+    m_pTaskCompleteSemaphore = SemaphoreNew();
+
+    // we create one less thread than m_NumThreads as the main thread counts as one
+    m_pThreadDataStore   = NewArray<ThreadDataStore>( m_NumThreads, ENKI_FILE_AND_LINE );
+    m_pThreads           = NewArray<std::thread>( m_NumThreads, ENKI_FILE_AND_LINE );
+    m_bRunning = true;
+    m_bWaitforAllCalled = false;
+    m_bShutdownRequested = false;
+
+    // current thread is primary enkiTS thread
+    m_pThreadDataStore[0].threadState = ENKI_THREAD_STATE_PRIMARY_REGISTERED;
+    gtl_threadNum = 0;
+
+    for( uint32_t thread = GetNumFirstExternalTaskThread(); thread < m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); ++thread )
+    {
+        m_pThreadDataStore[thread].threadState   = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
+    }
+    for( uint32_t thread = m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
+    {
+        m_pThreadDataStore[thread].threadState   = ENKI_THREAD_STATE_NOT_LAUNCHED;
+    }
+    // only launch threads once all thread states are set
+    for( uint32_t thread = m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
+    {
+        m_pThreads[thread]                       = std::thread( TaskingThreadFunction, ThreadArgs{ thread, this } );
+        ++m_NumInternalTaskThreadsRunning;
+    }
+
+    // Create Wait New Pinned Task Semaphores and init rndSeed
+    for( uint32_t threadNum = 0; threadNum < m_NumThreads; ++threadNum )
+    {
+        m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore = SemaphoreNew();
+        m_pThreadDataStore[threadNum].rndSeed = threadNum;
+    }
+
+    // ensure we have sufficient tasks to equally fill either all threads including main
+    // or just the threads we've launched, this is outside the firstinit as we want to be able
+    // to runtime change it
+    if( 1 == m_NumThreads )
+    {
+        m_NumPartitions        = 1;
+        m_NumInitialPartitions = 1;
+    }
+    else
+    {
+        // There could be more threads than hardware threads if external threads are
+        // being intended for blocking functionality such as io etc.
+        // We only need to partition for a maximum of the available processor parallelism.
+        uint32_t numThreadsToPartitionFor = std::min( m_NumThreads, GetNumHardwareThreads() );
+        m_NumPartitions = numThreadsToPartitionFor * (numThreadsToPartitionFor - 1);
+        // ensure m_NumPartitions, m_NumInitialPartitions non zero, can happen if m_NumThreads > 1 && GetNumHardwareThreads() == 1
+        m_NumPartitions        = std::max( m_NumPartitions,              (uint32_t)1 );
+        m_NumInitialPartitions = std::max( numThreadsToPartitionFor - 1, (uint32_t)1 );
+        m_NumInitialPartitions = std::min( m_NumInitialPartitions, gc_MaxNumInitialPartitions );
+    }
+
+#ifdef _WIN64
+    // x64 bit Windows may support >64 logical processors using processor groups, and only allocate threads to a default group.
+    // We need to detect this and distribute threads accordingly
+    if( GetNumHardwareThreads() > 64 &&                                    // only have processor groups if > 64 hardware threads
+        std::thread::hardware_concurrency() < GetNumHardwareThreads() &&   // if std::thread sees > 64 hardware threads no need to distribute
+        std::thread::hardware_concurrency() < m_NumThreads )               // no need to distrbute if number of threads requested lower than std::thread sees
+    {
+        uint32_t numProcessorGroups = GetActiveProcessorGroupCount();
+        GROUP_AFFINITY mainThreadAffinity;
+        BOOL success = GetThreadGroupAffinity( GetCurrentThread(), &mainThreadAffinity );
+        assert( success );
+        if( success )
+        {
+            uint32_t mainProcessorGroup = mainThreadAffinity.Group;
+            uint32_t currLogicalProcess = GetActiveProcessorCount( mainProcessorGroup ); // we start iteration at end of current process group's threads
+
+            // If more threads are created than there are logical processors then we still want to distribute them evenly amongst groups
+            // so we iterate continously around the groups until we reach m_NumThreads
+            uint32_t group = 0;
+            while( currLogicalProcess < m_NumThreads )
+            {
+                ++group; // start at group 1 since we set currLogicalProcess to start of next group
+                uint32_t currGroup = ( group + mainProcessorGroup ) % numProcessorGroups; // we start at mainProcessorGroup, go round in circles
+                uint32_t groupNumLogicalProcessors = GetActiveProcessorCount( currGroup );
+                assert( groupNumLogicalProcessors <= 64 );
+                uint64_t GROUPMASK = 0xFFFFFFFFFFFFFFFFULL >> (64-groupNumLogicalProcessors); // group mask should not have 1's where there are no processors
+                for( uint32_t groupLogicalProcess = 0; ( groupLogicalProcess < groupNumLogicalProcessors ) && ( currLogicalProcess < m_NumThreads ); ++groupLogicalProcess, ++currLogicalProcess )
+                {
+                    if( currLogicalProcess > m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread() )
+                    {
+                        auto thread_handle = m_pThreads[currLogicalProcess].native_handle();
+
+                        // From https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups
+                        // If a thread is assigned to a different group than the process, the process's affinity is updated to include the thread's affinity
+                        // and the process becomes a multi-group process. 
+                        GROUP_AFFINITY threadAffinity;
+                        success = GetThreadGroupAffinity( thread_handle, &threadAffinity );
+                        assert(success); (void)success;
+                        if( threadAffinity.Group != currGroup )
+                        {
+                            threadAffinity.Group = currGroup;
+                            threadAffinity.Mask  = GROUPMASK;
+                            success = SetThreadGroupAffinity( thread_handle, &threadAffinity, nullptr );
+                            assert( success ); (void)success;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+
+    m_bHaveThreads = true;
+}
+
+void TaskScheduler::StopThreads( bool bWait_ )
+{
+    // we set m_bWaitforAllCalled to true to ensure any task which loop using this status exit
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+
+    // set status 
+    m_bShutdownRequested.store( true, std::memory_order_release );
+    m_bRunning.store( false, std::memory_order_release );
+
+    if( m_bHaveThreads )
+    {
+
+        // wait for threads to quit before deleting data
+        while( bWait_ && m_NumInternalTaskThreadsRunning )
+        {
+            // keep firing event to ensure all threads pick up state of m_bRunning
+           WakeThreadsForNewTasks();
+
+           for( uint32_t threadId = 0; threadId < m_NumThreads; ++threadId )
+           {
+               // send wait for new pinned tasks signal to ensure any waiting are awoken
+               SemaphoreSignal( *m_pThreadDataStore[ threadId ].pWaitNewPinnedTaskSemaphore, 1 );
+           }
+        }
+
+        // detach threads starting with thread GetNumFirstExternalTaskThread() (as 0 is initialization thread).
+        for( uint32_t thread = m_Config.numExternalTaskThreads +  GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
+        {
+            ENKI_ASSERT( m_pThreads[thread].joinable() );
+            m_pThreads[thread].join();
+        }
+
+        // delete any Wait New Pinned Task Semaphores
+        for( uint32_t threadNum = 0; threadNum < m_NumThreads; ++threadNum )
+        {
+            SemaphoreDelete( m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore );
+        }
+
+        DeleteArray( m_pThreadDataStore, m_NumThreads, ENKI_FILE_AND_LINE );
+        DeleteArray( m_pThreads, m_NumThreads, ENKI_FILE_AND_LINE );
+        m_pThreadDataStore = 0;
+        m_pThreads = 0;
+
+        SemaphoreDelete( m_pNewTaskSemaphore );
+        m_pNewTaskSemaphore = 0;
+        SemaphoreDelete( m_pTaskCompleteSemaphore );
+        m_pTaskCompleteSemaphore = 0;
+
+        m_bHaveThreads = false;
+        m_NumThreadsWaitingForNewTasks = 0;
+        m_NumThreadsWaitingForTaskCompletion = 0;
+        m_NumInternalTaskThreadsRunning = 0;
+        m_NumExternalTaskThreadsRegistered = 0;
+
+        for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+        {
+            DeleteArray( m_pPipesPerThread[ priority ], m_NumThreads, ENKI_FILE_AND_LINE );
+            m_pPipesPerThread[ priority ] = NULL;
+            DeleteArray( m_pPinnedTaskListPerThread[ priority ], m_NumThreads, ENKI_FILE_AND_LINE );
+            m_pPinnedTaskListPerThread[ priority ] = NULL;
+        }
+        m_NumThreads = 0;
+    }
+}
+
+bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t& hintPipeToCheck_io_ )
+{
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        if( TryRunTask( threadNum_, priority, hintPipeToCheck_io_ ) )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline uint32_t RotateLeft( uint32_t value, int32_t count ) 
+{
+	return ( value << count ) | ( value >> ( 32 - count ));
+}
+/*  xxHash variant based on documentation on
+    https://github.com/Cyan4973/xxHash/blob/eec5700f4d62113b47ee548edbc4746f61ffb098/doc/xxhash_spec.md
+
+    Copyright (c) Yann Collet
+
+    Permission is granted to copy and distribute this document for any purpose and without charge, including translations into other languages and incorporation into compilations, provided that the copyright notice and this notice are preserved, and that any substantive changes or deletions from the original are clearly marked. Distribution of this document is unlimited.
+*/
+static inline uint32_t Hash32( uint32_t in_ )
+{
+    static const uint32_t PRIME32_1 = 2654435761U;  // 0b10011110001101110111100110110001
+    static const uint32_t PRIME32_2 = 2246822519U;  // 0b10000101111010111100101001110111
+    static const uint32_t PRIME32_3 = 3266489917U;  // 0b11000010101100101010111000111101
+    static const uint32_t PRIME32_4 =  668265263U;  // 0b00100111110101001110101100101111
+    static const uint32_t PRIME32_5 =  374761393U;  // 0b00010110010101100110011110110001
+    static const uint32_t SEED      = 0; // can configure seed if needed
+
+    // simple hash of nodes, does not check if nodePool is compressed or not.
+    uint32_t acc = SEED + PRIME32_5;
+
+    // add node types to map, and also ensure that fully empty nodes are well distrubuted by hashing the pointer.
+    acc += in_;
+    acc = acc ^ (acc >> 15);
+    acc = acc * PRIME32_2;
+    acc = acc ^ (acc >> 13);
+    acc = acc * PRIME32_3;
+    acc = acc ^ (acc >> 16);
+    return (std::size_t)acc;
+}
+
+bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_t& hintPipeToCheck_io_ )
+{
+    // Run any tasks for this thread
+    RunPinnedTasks( threadNum_, priority_ );
+
+    // check for tasks
+    SubTaskSet subTask;
+    bool bHaveTask = m_pPipesPerThread[ priority_ ][ threadNum_ ].WriterTryReadFront( &subTask );
+
+    uint32_t threadToCheckStart = hintPipeToCheck_io_ % m_NumThreads;
+    uint32_t threadToCheck      = threadToCheckStart;
+    uint32_t checkCount = 0;
+    if( !bHaveTask )
+    {
+        bHaveTask = m_pPipesPerThread[ priority_ ][ threadToCheck ].ReaderTryReadBack( &subTask );
+        if( !bHaveTask )
+        {
+            // To prevent many threads checking the same task pipe for work we pseudorandomly distribute
+            // the starting thread which we start checking for tasks to run
+            uint32_t& rndSeed = m_pThreadDataStore[threadNum_].rndSeed;
+            ++rndSeed;
+            uint32_t threadToCheckOffset = Hash32( rndSeed * threadNum_ ); 
+            while( !bHaveTask && checkCount < m_NumThreads )
+            {
+                threadToCheck = ( threadToCheckOffset + checkCount ) % m_NumThreads;
+                if( threadToCheck != threadNum_ && threadToCheckOffset != threadToCheckStart )
+                {
+                    bHaveTask = m_pPipesPerThread[ priority_ ][ threadToCheck ].ReaderTryReadBack( &subTask );
+                }
+                ++checkCount;
+            }
+        }
+    }
+        
+    if( bHaveTask )
+    {
+        // update hint, will preserve value unless actually got task from another thread.
+        hintPipeToCheck_io_ = threadToCheck;
+
+        uint32_t partitionSize = subTask.partition.end - subTask.partition.start;
+        if( subTask.pTask->m_RangeToRun < partitionSize )
+        {
+            SubTaskSet taskToRun = SplitTask( subTask, subTask.pTask->m_RangeToRun );
+            uint32_t rangeToSplit = subTask.pTask->m_RangeToRun;
+            if( threadNum_ != threadToCheck )
+            {
+                // task was stolen from another thread
+                // in order to ensure other threads can get enough work we need to split into larger ranges
+                // these larger splits are then stolen and split themselves
+                // otherwise other threads must keep stealing from this thread, which may stall when pipe is full
+                rangeToSplit = std::max( rangeToSplit, (subTask.partition.end - subTask.partition.start) / gc_MaxStolenPartitions );
+            }
+            SplitAndAddTask( threadNum_, subTask, rangeToSplit );
+            taskToRun.pTask->ExecuteRange( taskToRun.partition, threadNum_ );
+            int prevCount = taskToRun.pTask->m_RunningCount.fetch_sub(1,std::memory_order_release );
+            if( gc_TaskStartCount == prevCount )
+            {
+                TaskComplete( taskToRun.pTask, true, threadNum_ );
+            }
+        }
+        else
+        {
+            // the task has already been divided up by AddTaskSetToPipe, so just run it
+            subTask.pTask->ExecuteRange( subTask.partition, threadNum_ );
+            int prevCount = subTask.pTask->m_RunningCount.fetch_sub(1,std::memory_order_release );
+            if( gc_TaskStartCount == prevCount )
+            {
+                TaskComplete( subTask.pTask, true, threadNum_ );
+            }
+        }
+    }
+
+    return bHaveTask;
+
+}
+
+void TaskScheduler::TaskComplete( ICompletable* pTask_, bool bWakeThreads_, uint32_t threadNum_ )
+{
+    // It must be impossible for a thread to enter the sleeping wait prior to the load of m_WaitingForTaskCount
+    // in this function, so we introduce an gc_TaskAlmostCompleteCount to prevent this.
+    ENKI_ASSERT( gc_TaskAlmostCompleteCount == pTask_->m_RunningCount.load( std::memory_order_acquire ) );
+    bool bCallWakeThreads = bWakeThreads_ && pTask_->m_WaitingForTaskCount.load( std::memory_order_acquire );
+
+    Dependency* pDependent = pTask_->m_pDependents;
+
+    // Do not access pTask_ below this line unless we have dependencies.
+    pTask_->m_RunningCount.store( 0, std::memory_order_release );
+
+    if( bCallWakeThreads )
+    {
+        WakeThreadsForTaskCompletion();
+    }
+
+    while( pDependent )
+    {
+        // access pTaskToRunOnCompletion member data before incrementing m_DependenciesCompletedCount so
+        // they do not get deleted when another thread completes the pTaskToRunOnCompletion
+        int32_t dependenciesCount  = pDependent->pTaskToRunOnCompletion->m_DependenciesCount;
+        // get temp copy of pDependent so OnDependenciesComplete can delete task if needed.
+        Dependency* pDependentCurr = pDependent;
+        pDependent                 = pDependent->pNext;
+        int32_t prevDeps = pDependentCurr->pTaskToRunOnCompletion->m_DependenciesCompletedCount.fetch_add( 1, std::memory_order_release );
+        ENKI_ASSERT( prevDeps < dependenciesCount );
+        if( dependenciesCount == ( prevDeps + 1 ) )
+        {
+            // reset dependencies
+            // only safe to access pDependentCurr here after above fetch_add because this is the thread
+            // which calls OnDependenciesComplete after store with memory_order_release
+            pDependentCurr->pTaskToRunOnCompletion->m_DependenciesCompletedCount.store(
+                0,
+                std::memory_order_release );
+            pDependentCurr->pTaskToRunOnCompletion->OnDependenciesComplete( this, threadNum_ );
+        }
+    }
+}
+
+bool TaskScheduler::HaveTasks(  uint32_t threadNum_ )
+{
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        for( uint32_t thread = 0; thread < m_NumThreads; ++thread )
+        {
+            if( !m_pPipesPerThread[ priority ][ thread ].IsPipeEmpty() )
+            {
+                return true;
+            }
+        }
+        if( !m_pPinnedTaskListPerThread[ priority ][ threadNum_ ].IsListEmpty() )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void TaskScheduler::WaitForNewTasks( uint32_t threadNum_ )
+{
+    // We don't want to suspend this thread if there are task threads
+    // with pinned tasks suspended, as it could result in this thread
+    // being unsuspended and not the thread with pinned tasks
+    if( WakeSuspendedThreadsWithPinnedTasks() )
+    {
+        return;
+    }
+
+    // We incrememt the number of threads waiting here in order
+    // to ensure that the check for tasks occurs after the increment
+    // to prevent a task being added after a check, then the thread waiting.
+    // This will occasionally result in threads being mistakenly awoken,
+    // but they will then go back to sleep.
+    m_NumThreadsWaitingForNewTasks.fetch_add( 1, std::memory_order_acquire );
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_WAIT_NEW_TASKS, std::memory_order_seq_cst );
+
+    if( HaveTasks( threadNum_ ) )
+    {
+        m_NumThreadsWaitingForNewTasks.fetch_sub( 1, std::memory_order_release );
+    }
+    else
+    {
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStart, threadNum_ );
+        SemaphoreWait( *m_pNewTaskSemaphore );
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStop, threadNum_ );
+    }
+
+    m_pThreadDataStore[threadNum_].threadState.store( prevThreadState, std::memory_order_release );
+}
+
+void TaskScheduler::WaitForTaskCompletion( const ICompletable* pCompletable_, uint32_t threadNum_ )
+{
+    // We don't want to suspend this thread if there are task threads
+    // with pinned tasks suspended, as the completable could be a pinned task
+    // or it could be waiting on one.
+    if( WakeSuspendedThreadsWithPinnedTasks() )
+    {
+        return;
+    }
+
+    m_NumThreadsWaitingForTaskCompletion.fetch_add( 1, std::memory_order_acquire );
+    pCompletable_->m_WaitingForTaskCount.fetch_add( 1, std::memory_order_acquire );
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_WAIT_TASK_COMPLETION, std::memory_order_seq_cst );
+
+    // do not wait on semaphore if task in gc_TaskAlmostCompleteCount state.
+    if( gc_TaskAlmostCompleteCount >= pCompletable_->m_RunningCount.load( std::memory_order_acquire ) || HaveTasks( threadNum_ ) )
+    {
+        m_NumThreadsWaitingForTaskCompletion.fetch_sub( 1, std::memory_order_release );
+    }
+    else
+    {
+        SafeCallback( m_Config.profilerCallbacks.waitForTaskCompleteSuspendStart, threadNum_ );
+        std::atomic_thread_fence(std::memory_order_acquire);
+
+        SemaphoreWait( *m_pTaskCompleteSemaphore );
+        if( !pCompletable_->GetIsComplete() )
+        {
+            // This thread which may not the one which was supposed to be awoken
+            WakeThreadsForTaskCompletion();
+        }
+        SafeCallback( m_Config.profilerCallbacks.waitForTaskCompleteSuspendStop, threadNum_ );
+    }
+
+    m_pThreadDataStore[threadNum_].threadState.store( prevThreadState, std::memory_order_release );
+    pCompletable_->m_WaitingForTaskCount.fetch_sub( 1, std::memory_order_release );
+}
+
+void TaskScheduler::WakeThreadsForNewTasks()
+{
+    int32_t waiting = m_NumThreadsWaitingForNewTasks.load( std::memory_order_relaxed );
+    while( waiting > 0 && !m_NumThreadsWaitingForNewTasks.compare_exchange_weak(waiting, 0, std::memory_order_release, std::memory_order_relaxed ) ) {}
+
+    if( waiting > 0 )
+    {
+        SemaphoreSignal( *m_pNewTaskSemaphore, waiting );
+    }
+
+    // We also wake tasks waiting for completion as they can run tasks
+    WakeThreadsForTaskCompletion();
+}
+
+void TaskScheduler::WakeThreadsForTaskCompletion()
+{
+    // m_NumThreadsWaitingForTaskCompletion can go negative as this indicates that
+    // we signalled more threads than the number which ended up waiting
+    int32_t waiting = m_NumThreadsWaitingForTaskCompletion.load( std::memory_order_relaxed );
+    while( waiting > 0 && !m_NumThreadsWaitingForTaskCompletion.compare_exchange_weak(waiting, 0, std::memory_order_release, std::memory_order_relaxed ) ) {}
+
+    if( waiting > 0 )
+    {
+        SemaphoreSignal( *m_pTaskCompleteSemaphore, waiting );
+    }
+}
+
+bool TaskScheduler::WakeSuspendedThreadsWithPinnedTasks()
+{
+    uint32_t threadNum = gtl_threadNum;
+    for( uint32_t t = 1; t < m_NumThreads; ++t )
+    {
+        // distribute thread checks more evenly by starting at our thread number rather than 0.
+        uint32_t thread = ( threadNum + t ) % m_NumThreads;
+
+        ThreadState state = m_pThreadDataStore[ thread ].threadState.load( std::memory_order_acquire );
+            
+        ENKI_ASSERT( state != ENKI_THREAD_STATE_NONE );
+
+        if( state == ENKI_THREAD_STATE_WAIT_NEW_TASKS || state == ENKI_THREAD_STATE_WAIT_TASK_COMPLETION )
+        {
+            // thread is suspended, check if it has pinned tasks
+            for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+            {
+                if( !m_pPinnedTaskListPerThread[ priority ][ thread ].IsListEmpty() )
+                {
+                    WakeThreadsForNewTasks();
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void TaskScheduler::SplitAndAddTask( uint32_t threadNum_, SubTaskSet subTask_, uint32_t rangeToSplit_ )
+{
+    int32_t numAdded = 0;
+    int32_t numNewTasksSinceNotification = 0;
+    int32_t numRun   = 0;
+
+    int32_t upperBoundNumToAdd = 2 + (int32_t)( ( subTask_.partition.end - subTask_.partition.start ) / rangeToSplit_ );
+
+    // ensure that an artificial completion is not registered whilst adding tasks by incrementing count
+    subTask_.pTask->m_RunningCount.fetch_add( upperBoundNumToAdd, std::memory_order_acquire );
+    while( subTask_.partition.start != subTask_.partition.end )
+    {
+        SubTaskSet taskToAdd = SplitTask( subTask_, rangeToSplit_ );
+
+        // add the partition to the pipe
+        ++numAdded; ++numNewTasksSinceNotification;
+        if( !m_pPipesPerThread[ subTask_.pTask->m_Priority ][ threadNum_ ].WriterTryWriteFront( taskToAdd ) )
+        {
+            --numAdded; // we were unable to add the task
+            if( numNewTasksSinceNotification > 1 )
+            {
+                WakeThreadsForNewTasks();
+            }
+            numNewTasksSinceNotification = 0;
+            // alter range to run the appropriate fraction
+            if( taskToAdd.pTask->m_RangeToRun < taskToAdd.partition.end - taskToAdd.partition.start )
+            {
+                taskToAdd.partition.end = taskToAdd.partition.start + taskToAdd.pTask->m_RangeToRun;
+                ENKI_ASSERT( taskToAdd.partition.end <= taskToAdd.pTask->m_SetSize );
+                subTask_.partition.start = taskToAdd.partition.end;
+            }
+            taskToAdd.pTask->ExecuteRange( taskToAdd.partition, threadNum_ );
+            ++numRun;
+        }
+    }
+    int32_t countToRemove = upperBoundNumToAdd - numAdded;
+    ENKI_ASSERT( countToRemove > 0 );
+    int prevCount = subTask_.pTask->m_RunningCount.fetch_sub( countToRemove, std::memory_order_release );
+    if( countToRemove-1 + gc_TaskStartCount == prevCount )
+    {
+        TaskComplete( subTask_.pTask, false, threadNum_ );
+    }
+
+    // WakeThreadsForNewTasks also calls WakeThreadsForTaskCompletion() so do not need to do so above
+    WakeThreadsForNewTasks();
+}
+
+TaskSchedulerConfig TaskScheduler::GetConfig() const
+{
+    return m_Config;
+}
+
+void TaskScheduler::AddTaskSetToPipeInt( ITaskSet* pTaskSet_, uint32_t threadNum_ )
+{
+    ENKI_ASSERT( pTaskSet_->m_RunningCount == gc_TaskStartCount );
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+
+    // divide task up and add to pipe
+    pTaskSet_->m_RangeToRun = pTaskSet_->m_SetSize / m_NumPartitions;
+    pTaskSet_->m_RangeToRun = std::max( pTaskSet_->m_RangeToRun, pTaskSet_->m_MinRange );
+    // Note: if m_SetSize is < m_RangeToRun this will be handled by SplitTask and so does not need to be handled here
+
+    uint32_t rangeToSplit = pTaskSet_->m_SetSize / m_NumInitialPartitions;
+    rangeToSplit = std::max( rangeToSplit, pTaskSet_->m_MinRange );
+
+    SubTaskSet subTask;
+    subTask.pTask = pTaskSet_;
+    subTask.partition.start = 0;
+    subTask.partition.end = pTaskSet_->m_SetSize;
+    SplitAndAddTask( threadNum_, subTask, rangeToSplit );
+    int prevCount = pTaskSet_->m_RunningCount.fetch_sub(1, std::memory_order_release );
+    if( gc_TaskStartCount == prevCount )
+    {
+        TaskComplete( pTaskSet_, true, threadNum_ );
+    }
+
+    m_pThreadDataStore[threadNum_].threadState.store( prevThreadState, std::memory_order_release );
+}
+
+void TaskScheduler::AddTaskSetToPipe( ITaskSet* pTaskSet_ )
+{
+    ENKI_ASSERT( pTaskSet_->m_RunningCount == 0 );
+    InitDependencies( pTaskSet_ );
+    pTaskSet_->m_RunningCount.store( gc_TaskStartCount, std::memory_order_relaxed );
+    AddTaskSetToPipeInt( pTaskSet_, gtl_threadNum );
+}
+
+void  TaskScheduler::AddPinnedTaskInt( IPinnedTask* pTask_ )
+{
+    ENKI_ASSERT( pTask_->m_RunningCount == gc_TaskStartCount );
+    m_pPinnedTaskListPerThread[ pTask_->m_Priority ][ pTask_->threadNum ].WriterWriteFront( pTask_ );
+
+    ThreadState statePinnedTaskThread = m_pThreadDataStore[ pTask_->threadNum ].threadState.load( std::memory_order_acquire );
+    if( statePinnedTaskThread == ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS )
+    {
+        SemaphoreSignal( *m_pThreadDataStore[ pTask_->threadNum ].pWaitNewPinnedTaskSemaphore, 1 );
+    }
+    else
+    {
+        WakeThreadsForNewTasks();
+    }
+}
+
+void TaskScheduler::AddPinnedTask( IPinnedTask* pTask_ )
+{
+    ENKI_ASSERT( pTask_->m_RunningCount == 0 );
+    InitDependencies( pTask_ );
+    pTask_->m_RunningCount = gc_TaskStartCount;
+    AddPinnedTaskInt( pTask_ );
+}
+
+void TaskScheduler::InitDependencies( ICompletable* pCompletable_ )
+{
+    // go through any dependencies and set thier running count so they show as not complete
+    // and increment depedency count
+    if( pCompletable_->m_RunningCount.load( std::memory_order_relaxed ) )
+    {
+        // already initialized
+        return;
+    }
+    Dependency* pDependent = pCompletable_->m_pDependents;
+    while( pDependent )
+    {
+        InitDependencies( pDependent->pTaskToRunOnCompletion );
+        pDependent->pTaskToRunOnCompletion->m_RunningCount.store( gc_TaskStartCount, std::memory_order_relaxed );
+        pDependent = pDependent->pNext;
+    }
+}
+
+
+void TaskScheduler::RunPinnedTasks()
+{
+    uint32_t threadNum = gtl_threadNum;
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
+    std::atomic_thread_fence(std::memory_order_acquire);
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        RunPinnedTasks( threadNum, priority );
+    }
+    m_pThreadDataStore[threadNum].threadState.store( prevThreadState, std::memory_order_release );
+}
+
+void TaskScheduler::RunPinnedTasks( uint32_t threadNum_, uint32_t priority_ )
+{
+    IPinnedTask* pPinnedTaskSet = NULL;
+    do
+    {
+        pPinnedTaskSet = m_pPinnedTaskListPerThread[ priority_ ][ threadNum_ ].ReaderReadBack();
+        if( pPinnedTaskSet )
+        {
+            pPinnedTaskSet->Execute();
+            pPinnedTaskSet->m_RunningCount.fetch_sub(1,std::memory_order_release);
+            TaskComplete( pPinnedTaskSet, true, threadNum_ );
+        }
+    } while( pPinnedTaskSet );
+}
+
+void    TaskScheduler::WaitforTask( const ICompletable* pCompletable_, enki::TaskPriority priorityOfLowestToRun_ )
+{
+    uint32_t threadNum = gtl_threadNum;
+    uint32_t hintPipeToCheck_io = threadNum + 1;    // does not need to be clamped.
+
+    // waiting for a task is equivalent to 'running' for thread state purpose as we may run tasks whilst waiting
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
+    std::atomic_thread_fence(std::memory_order_acquire);
+
+
+    if( pCompletable_ && !pCompletable_->GetIsComplete() )
+    {
+        SafeCallback( m_Config.profilerCallbacks.waitForTaskCompleteStart, threadNum );
+        // We need to ensure that the task we're waiting on can complete even if we're the only thread,
+        // so we clamp the priorityOfLowestToRun_ to no smaller than the task we're waiting for
+        priorityOfLowestToRun_ = std::max( priorityOfLowestToRun_, pCompletable_->m_Priority );
+        uint32_t spinCount = 0;
+        while( !pCompletable_->GetIsComplete() && GetIsRunning() )
+        {
+            ++spinCount;
+            for( int priority = 0; priority <= priorityOfLowestToRun_; ++priority )
+            {
+                if( TryRunTask( threadNum, priority, hintPipeToCheck_io ) )
+                {
+                    spinCount = 0; // reset spin as ran a task
+                    break;
+                }
+            }
+            if( spinCount > gc_SpinCount )
+            {
+                WaitForTaskCompletion( pCompletable_, threadNum );
+                spinCount = 0;
+            }
+            else
+            {
+                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+                SpinWait( spinBackoffCount );
+            }
+        }
+        SafeCallback( m_Config.profilerCallbacks.waitForTaskCompleteStop, threadNum );
+    }
+    else if( nullptr == pCompletable_ )
+    {
+            for( int priority = 0; priority <= priorityOfLowestToRun_; ++priority )
+            {
+                if( TryRunTask( gtl_threadNum, priority, hintPipeToCheck_io ) )
+                {
+                    break;
+                }
+            }
+    }
+
+    m_pThreadDataStore[threadNum].threadState.store( prevThreadState, std::memory_order_release );
+
+}
+
+class TaskSchedulerWaitTask : public IPinnedTask
+{
+    void Execute() override
+    {
+        // do nothing
+    }
+};
+
+void TaskScheduler::WaitforAll()
+{
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+
+    bool bHaveTasks = true;
+    uint32_t ourThreadNum = gtl_threadNum;
+    uint32_t hintPipeToCheck_io = ourThreadNum  + 1;    // does not need to be clamped.
+    bool otherThreadsRunning = false; // account for this thread
+    uint32_t spinCount = 0;
+    TaskSchedulerWaitTask dummyWaitTask;
+    dummyWaitTask.threadNum = 0;
+    while( GetIsRunning() && ( bHaveTasks || otherThreadsRunning ) )
+    {
+        bHaveTasks = TryRunTask( ourThreadNum, hintPipeToCheck_io );
+        ++spinCount;
+        if( bHaveTasks )
+        {
+            spinCount = 0; // reset spin as ran a task
+        }
+        if( spinCount > gc_SpinCount )
+        {
+            // find a running thread and add a dummy wait task
+            int32_t countThreadsToCheck = m_NumThreads - 1;
+            bool bHaveThreadToWaitOn = false;
+            do
+            {
+                --countThreadsToCheck;
+                dummyWaitTask.threadNum = ( dummyWaitTask.threadNum + 1 ) % m_NumThreads;
+
+                // We can only add a pinned task to wait on if we find an enki Task Thread which isn't this thread.
+                // Otherwise we have to busy wait.
+                if( dummyWaitTask.threadNum != ourThreadNum && dummyWaitTask.threadNum > m_Config.numExternalTaskThreads )
+                {
+                    ThreadState state = m_pThreadDataStore[ dummyWaitTask.threadNum ].threadState.load( std::memory_order_acquire );
+                    if( state == ENKI_THREAD_STATE_RUNNING || state == ENKI_THREAD_STATE_WAIT_TASK_COMPLETION )
+                    {
+                        bHaveThreadToWaitOn = true;
+                        break;
+                    }
+                }
+            } while( countThreadsToCheck );
+
+            if( bHaveThreadToWaitOn )
+            {
+                ENKI_ASSERT( dummyWaitTask.threadNum != ourThreadNum );
+                AddPinnedTask( &dummyWaitTask );
+                WaitforTask( &dummyWaitTask );
+            }
+            spinCount = 0;
+        }
+        else
+        {
+            uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+            SpinWait( spinBackoffCount );
+        }
+
+        // count threads running
+        otherThreadsRunning = false;
+        for(uint32_t thread = 0; thread < m_NumThreads && !otherThreadsRunning; ++thread )
+        {
+            // ignore our thread
+            if( thread != ourThreadNum )
+            {
+                switch( m_pThreadDataStore[thread].threadState.load( std::memory_order_acquire ) )
+                {
+                case ENKI_THREAD_STATE_NONE:
+                    ENKI_ASSERT(false);
+                    break;
+                case ENKI_THREAD_STATE_NOT_LAUNCHED:
+                case ENKI_THREAD_STATE_RUNNING:
+                case ENKI_THREAD_STATE_WAIT_TASK_COMPLETION:
+                    otherThreadsRunning = true;
+                    break;
+                case ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS:
+                    otherThreadsRunning = true;
+                    SemaphoreSignal( *m_pThreadDataStore[thread].pWaitNewPinnedTaskSemaphore, 1 );
+                    break;
+                case ENKI_THREAD_STATE_PRIMARY_REGISTERED:
+                case ENKI_THREAD_STATE_EXTERNAL_REGISTERED:
+                case ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED:
+                case ENKI_THREAD_STATE_WAIT_NEW_TASKS:
+                case ENKI_THREAD_STATE_STOPPED:
+                    break;
+                 };
+            }
+        }
+        if( !otherThreadsRunning )
+        {
+            // check there are no tasks
+            for(uint32_t thread = 0; thread < m_NumThreads && !otherThreadsRunning; ++thread )
+            {
+                // ignore our thread
+                if( thread != ourThreadNum )
+                {
+                    otherThreadsRunning = HaveTasks( thread );
+                }
+            }
+        }
+     }
+
+    m_bWaitforAllCalled.store( false, std::memory_order_release );
+}
+
+void TaskScheduler::WaitforAllAndShutdown()
+{
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+    m_bShutdownRequested.store( true, std::memory_order_release );
+    if( m_bHaveThreads )
+    {
+        WaitforAll();
+        StopThreads(true);
+    }
+}
+
+void TaskScheduler::ShutdownNow()
+{
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+    m_bShutdownRequested.store( true, std::memory_order_release );
+    if( m_bHaveThreads )
+    {
+        StopThreads(true);
+    }
+}
+
+void TaskScheduler::WaitForNewPinnedTasks()
+{
+    uint32_t threadNum = gtl_threadNum;
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS, std::memory_order_seq_cst );
+
+    // check if have tasks inside threadState change but before waiting
+    bool bHavePinnedTasks = false;
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        if( !m_pPinnedTaskListPerThread[ priority ][ threadNum ].IsListEmpty() )
+        {
+            bHavePinnedTasks = true;
+            break;
+        }
+    }
+
+    if( !bHavePinnedTasks )
+    {
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStart, threadNum );
+        SemaphoreWait( *m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore );
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStop, threadNum );
+    }
+
+    m_pThreadDataStore[threadNum].threadState.store( prevThreadState, std::memory_order_release );
+}
+
+
+uint32_t        TaskScheduler::GetNumTaskThreads() const
+{
+    return m_NumThreads;
+}
+
+
+uint32_t TaskScheduler::GetThreadNum() const
+{
+    return gtl_threadNum;
+}
+
+template<typename T>
+T* TaskScheduler::NewArray( size_t num_, const char* file_, int line_  )
+{
+    T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), num_*sizeof(T), m_Config.customAllocator.userData, file_, line_ );
+    if( !std::is_trivial<T>::value )
+    {
+		T* pCurr = pRet;
+        for( size_t i = 0; i < num_; ++i )
+        {
+			void* pBuffer = pCurr;
+            pCurr = new(pBuffer) T;
+			++pCurr;
+        }
+    }
+    return pRet;
+}
+
+template<typename T>
+void TaskScheduler::DeleteArray( T* p_, size_t num_, const char* file_, int line_ )
+{
+    if( !std::is_trivially_destructible<T>::value )
+    {
+        size_t i = num_;
+        while(i)
+        {
+            p_[--i].~T();
+        }
+    }
+    m_Config.customAllocator.free( p_, sizeof(T)*num_, m_Config.customAllocator.userData, file_, line_ );
+}
+
+template<class T, class... Args>
+T* TaskScheduler::New( const char* file_, int line_, Args&&... args_ )
+{
+    T* pRet = this->Alloc<T>( file_, line_ );
+    return new(pRet) T( std::forward<Args>(args_)... );
+}
+
+template< typename T >
+void TaskScheduler::Delete( T* p_, const char* file_, int line_  )
+{
+    p_->~T(); 
+    this->Free(p_, file_, line_ );
+}
+
+template< typename T >
+T* TaskScheduler::Alloc( const char* file_, int line_  )
+{
+    T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), sizeof(T), m_Config.customAllocator.userData, file_, line_ );
+    return pRet;
+}
+
+template< typename T >
+void TaskScheduler::Free( T* p_, const char* file_, int line_  )
+{
+    m_Config.customAllocator.free( p_, sizeof(T), m_Config.customAllocator.userData, file_, line_ );
+}
+
+TaskScheduler::TaskScheduler()
+        : m_pPipesPerThread()
+        , m_pPinnedTaskListPerThread()
+        , m_NumThreads(0)
+        , m_pThreadDataStore(NULL)
+        , m_pThreads(NULL)
+        , m_bRunning(0)
+        , m_NumInternalTaskThreadsRunning(0)
+        , m_NumThreadsWaitingForNewTasks(0)
+        , m_NumThreadsWaitingForTaskCompletion(0)
+        , m_NumPartitions(0)
+        , m_pNewTaskSemaphore(NULL)
+        , m_pTaskCompleteSemaphore(NULL)
+        , m_NumInitialPartitions(0)
+        , m_bHaveThreads(false)
+        , m_NumExternalTaskThreadsRegistered(0)
+{
+}
+
+TaskScheduler::~TaskScheduler()
+{
+    StopThreads( true ); // Stops threads, waiting for them.
+}
+
+void TaskScheduler::Initialize( uint32_t numThreadsTotal_ )
+{
+    ENKI_ASSERT( numThreadsTotal_ >= 1 );
+    StopThreads( true ); // Stops threads, waiting for them.
+    m_Config.numTaskThreadsToCreate = numThreadsTotal_ - 1;
+    m_Config.numExternalTaskThreads = 0;
+    StartThreads();}
+
+void TaskScheduler::Initialize( TaskSchedulerConfig config_ )
+{
+    StopThreads( true ); // Stops threads, waiting for them.
+    m_Config = config_;
+    StartThreads();
+}
+
+void TaskScheduler::Initialize()
+{
+    Initialize( std::thread::hardware_concurrency() );
+}
+
+// Semaphore implementation
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+
+namespace enki
+{
+    struct semaphoreid_t
+    {
+        HANDLE      sem;
+    };
+    
+    inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
+    {
+#ifdef _XBOX_ONE
+        semaphoreid.sem = CreateSemaphoreExW( NULL, 0, MAXLONG, NULL, 0, SEMAPHORE_ALL_ACCESS );
+#else
+        semaphoreid.sem = CreateSemaphore( NULL, 0, MAXLONG, NULL );
+#endif
+    }
+
+    inline void SemaphoreClose( semaphoreid_t& semaphoreid )
+    {
+        CloseHandle( semaphoreid.sem );
+    }
+
+    inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
+    {
+        DWORD retval = WaitForSingleObject( semaphoreid.sem, INFINITE );
+        ENKI_ASSERT( retval != WAIT_FAILED );
+        (void)retval; // only needed for ENKI_ASSERT
+    }
+
+    inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
+    {
+        if( countWaiting )
+        {
+            ReleaseSemaphore( semaphoreid.sem, countWaiting, NULL );
+        }
+    }
+}
+#elif defined(__MACH__)
+
+
+// OS X does not have POSIX semaphores
+// Mach semaphores can now only be created by the kernel
+// Named sempahores work, but would require unique name construction to ensure
+// they are isolated to this process.
+// Dispatch semaphores appear to be the way other developers use OSX Semaphores, e.g. Boost
+// However the API could change
+// OSX below 10.6 does not support dispatch, but I do not have an earlier OSX version
+// to test alternatives
+#include <dispatch/dispatch.h>
+
+namespace enki
+{
+    
+    struct semaphoreid_t
+    {
+        dispatch_semaphore_t   sem;
+    };
+    
+    inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
+    {
+        semaphoreid.sem = dispatch_semaphore_create(0);
+    }
+    
+    inline void SemaphoreClose( semaphoreid_t& semaphoreid )
+    {
+        dispatch_release( semaphoreid.sem );
+    }
+    
+    inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
+    {
+        dispatch_semaphore_wait( semaphoreid.sem, DISPATCH_TIME_FOREVER );
+    }
+    
+    inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
+    {
+        while( countWaiting-- > 0 )
+        {
+            dispatch_semaphore_signal( semaphoreid.sem );
+        }
+    }
+}
+
+#else // POSIX
+
+#include <semaphore.h>
+#include <errno.h>
+
+namespace enki
+{
+    
+    struct semaphoreid_t
+    {
+        sem_t   sem;
+    };
+    
+    inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
+    {
+        int err = sem_init( &semaphoreid.sem, 0, 0 );
+        ENKI_ASSERT( err == 0 );
+        (void)err;
+    }
+    
+    inline void SemaphoreClose( semaphoreid_t& semaphoreid )
+    {
+        sem_destroy( &semaphoreid.sem );
+    }
+    
+    inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
+    {
+        while( sem_wait( &semaphoreid.sem ) == -1 && errno == EINTR ) {}
+    }
+    
+    inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
+    {
+        while( countWaiting-- > 0 )
+        {
+            sem_post( &semaphoreid.sem );
+        }
+    }
+}
+#endif
+
+semaphoreid_t* TaskScheduler::SemaphoreNew()
+{
+    semaphoreid_t* pSemaphore = this->Alloc<semaphoreid_t>( ENKI_FILE_AND_LINE );
+    SemaphoreCreate( *pSemaphore );
+    return pSemaphore;
+}
+
+void TaskScheduler::SemaphoreDelete( semaphoreid_t* pSemaphore_ )
+{
+    SemaphoreClose( *pSemaphore_ );
+    this->Free( pSemaphore_, ENKI_FILE_AND_LINE );
+}
+
+void TaskScheduler::SetCustomAllocator( CustomAllocator customAllocator_ )
+{
+    m_Config.customAllocator = customAllocator_;
+}
+
+Dependency::Dependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ ) 
+    : pTaskToRunOnCompletion( pTaskToRunOnCompletion_ )
+    , pDependencyTask( pDependencyTask_ )
+    , pNext( pDependencyTask->m_pDependents )
+{
+    ENKI_ASSERT( pDependencyTask->GetIsComplete() );
+    ENKI_ASSERT( pTaskToRunOnCompletion->GetIsComplete() );
+    pDependencyTask->m_pDependents = this;
+    ++pTaskToRunOnCompletion->m_DependenciesCount;
+}
+
+Dependency::Dependency( Dependency&& rhs_ ) noexcept
+{
+    pDependencyTask   = rhs_.pDependencyTask;
+    pTaskToRunOnCompletion = rhs_.pTaskToRunOnCompletion;
+    pNext             = rhs_.pNext;
+    if( rhs_.pDependencyTask )
+    {
+        ENKI_ASSERT( rhs_.pTaskToRunOnCompletion );
+        ENKI_ASSERT( rhs_.pDependencyTask->GetIsComplete() );
+        ENKI_ASSERT( rhs_.pTaskToRunOnCompletion->GetIsComplete() );
+        Dependency** ppDependent = &(pDependencyTask->m_pDependents);
+        while( *ppDependent )
+        {
+            if( &rhs_ == *ppDependent )
+            {
+                *ppDependent = this;
+                break;
+            }
+            ppDependent = &((*ppDependent)->pNext);
+        }
+    }
+}
+
+
+Dependency::~Dependency()
+{
+    ClearDependency();
+}
+
+void Dependency::SetDependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ )
+{
+    ClearDependency();
+    ENKI_ASSERT( pDependencyTask_->GetIsComplete() );
+    ENKI_ASSERT( pTaskToRunOnCompletion_->GetIsComplete() );
+    pDependencyTask = pDependencyTask_;
+    pTaskToRunOnCompletion = pTaskToRunOnCompletion_;
+    pNext = pDependencyTask->m_pDependents;
+    pDependencyTask->m_pDependents = this;
+    ++pTaskToRunOnCompletion->m_DependenciesCount;
+}
+
+void Dependency::ClearDependency()
+{
+    if( pDependencyTask )
+    {
+        ENKI_ASSERT( pTaskToRunOnCompletion );
+        ENKI_ASSERT( pDependencyTask->GetIsComplete() );
+        ENKI_ASSERT( pTaskToRunOnCompletion->GetIsComplete() );
+        ENKI_ASSERT( pTaskToRunOnCompletion->m_DependenciesCount > 0 );
+        Dependency* pDependent = pDependencyTask->m_pDependents;
+        --pTaskToRunOnCompletion->m_DependenciesCount;
+        if( this == pDependent )
+        {
+            pDependencyTask->m_pDependents = pDependent->pNext;
+        }
+        else
+        {
+            while( pDependent )
+            {
+                Dependency* pPrev = pDependent;
+                pDependent = pDependent->pNext;
+                if( this == pDependent )
+                {
+                    pPrev->pNext = pDependent->pNext;
+                    break;
+                }
+            }
+        }
+    }
+    pDependencyTask = NULL;
+    pDependencyTask =  NULL;
+    pNext = NULL;
+}

--- a/Source/ThirdParty/enkiTS/src/TaskScheduler.h
+++ b/Source/ThirdParty/enkiTS/src/TaskScheduler.h
@@ -1,0 +1,574 @@
+// Copyright (c) 2013 Doug Binks
+// 
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// 
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgement in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+#include <atomic>
+#include <thread>
+#include <condition_variable>
+#include <stdint.h>
+#include <functional>
+
+// ENKITS_TASK_PRIORITIES_NUM can be set from 1 to 5.
+// 1 corresponds to effectively no priorities.
+#ifndef ENKITS_TASK_PRIORITIES_NUM
+    #define ENKITS_TASK_PRIORITIES_NUM 3
+#endif
+
+#ifndef	ENKITS_API
+#if   defined(_WIN32) && defined(ENKITS_BUILD_DLL)
+    // Building enkiTS as a DLL
+    #define ENKITS_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(ENKITS_DLL)
+    // Using enkiTS as a DLL
+    #define ENKITS_API __declspec(dllimport)
+#elif defined(__GNUC__) && defined(ENKITS_BUILD_DLL)
+    // Building enkiTS as a shared library
+    #define ENKITS_API __attribute__((visibility("default")))
+#else
+    #define ENKITS_API
+#endif
+#endif
+
+// Define ENKI_CUSTOM_ALLOC_FILE_AND_LINE (at project level) to get file and line report in custom allocators,
+// this is default in Debug - to turn off define ENKI_CUSTOM_ALLOC_NO_FILE_AND_LINE
+#ifndef ENKI_CUSTOM_ALLOC_FILE_AND_LINE
+#if defined(_DEBUG ) && !defined(ENKI_CUSTOM_ALLOC_NO_FILE_AND_LINE)
+#define ENKI_CUSTOM_ALLOC_FILE_AND_LINE
+#endif
+#endif
+
+#ifndef ENKI_ASSERT
+#include <assert.h>
+#define ENKI_ASSERT(x) assert(x)
+#endif
+
+namespace enki
+{
+
+    struct TaskSetPartition
+    {
+        uint32_t start;
+        uint32_t end;
+    };
+
+    class  TaskScheduler;
+    class  TaskPipe;
+    class  PinnedTaskList;
+    class  Dependency;
+    struct ThreadArgs;
+    struct ThreadDataStore;
+    struct SubTaskSet;
+    struct semaphoreid_t;
+
+    ENKITS_API uint32_t GetNumHardwareThreads();
+
+    enum TaskPriority
+    {
+        TASK_PRIORITY_HIGH   = 0,
+#if ( ENKITS_TASK_PRIORITIES_NUM > 3 )
+        TASK_PRIORITY_MED_HI,
+#endif
+#if ( ENKITS_TASK_PRIORITIES_NUM > 2 )
+        TASK_PRIORITY_MED,
+#endif
+#if ( ENKITS_TASK_PRIORITIES_NUM > 4 )
+        TASK_PRIORITY_MED_LO,
+#endif 
+#if ( ENKITS_TASK_PRIORITIES_NUM > 1 )
+        TASK_PRIORITY_LOW,
+#endif
+        TASK_PRIORITY_NUM
+    };
+
+    // ICompletable is a base class used to check for completion.
+    // Can be used with dependencies to wait for their completion.
+    // Derive from ITaskSet or IPinnedTask for running parallel tasks.
+    class ICompletable
+    {
+    public:
+        bool    GetIsComplete() const {
+            return 0 == m_RunningCount.load( std::memory_order_acquire );
+        }
+
+        virtual ~ICompletable();
+
+        // Dependency helpers, see Dependencies.cpp
+        void SetDependency( Dependency& dependency_, const ICompletable* pDependencyTask_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D& dependencyArray_ , const T(&taskArray_)[SIZE] );
+        template<typename D, typename T>           void SetDependenciesArr( D& dependencyArray_, std::initializer_list<T*> taskpList_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D(&dependencyArray_)[SIZE], const T(&taskArray_)[SIZE] );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D(&dependencyArray_)[SIZE], std::initializer_list<T*> taskpList_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesVec( D& dependencyVec_, const T(&taskArray_)[SIZE] );
+        template<typename D, typename T>           void SetDependenciesVec( D& dependencyVec_, std::initializer_list<T*> taskpList_ );
+
+        TaskPriority                   m_Priority            = TASK_PRIORITY_HIGH;
+    protected:
+        // Deriving from an ICompletable and overriding OnDependenciesComplete is advanced use.
+        // If you do override OnDependenciesComplete() call:
+        // ICompletable::OnDependenciesComplete( pTaskScheduler_, threadNum_ );
+        // in your implementation.
+        virtual void                   OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ );
+    private:
+        friend class                   TaskScheduler;
+        friend class                   Dependency;
+        std::atomic<int32_t>           m_RunningCount               = {0};
+        std::atomic<int32_t>           m_DependenciesCompletedCount = {0};
+        int32_t                        m_DependenciesCount          = 0;
+        mutable std::atomic<int32_t>   m_WaitingForTaskCount        = {0};
+        mutable Dependency*            m_pDependents                = NULL;
+    };
+
+    // Subclass ITaskSet to create tasks.
+    // TaskSets can be re-used, but check completion first.
+    class ITaskSet : public ICompletable
+    {
+    public:
+        ITaskSet() = default;
+        ITaskSet( uint32_t setSize_ )
+            : m_SetSize( setSize_ )
+        {}
+
+        ITaskSet( uint32_t setSize_, uint32_t minRange_ )
+            : m_SetSize( setSize_ )
+            , m_MinRange( minRange_ )
+            , m_RangeToRun(minRange_)
+        {}
+
+        // Execute range should be overloaded to process tasks. It will be called with a
+        // range_ where range.start >= 0; range.start < range.end; and range.end < m_SetSize;
+        // The range values should be mapped so that linearly processing them in order is cache friendly
+        // i.e. neighbouring values should be close together.
+        // threadnum should not be used for changing processing of data, it's intended purpose
+        // is to allow per-thread data buckets for output.
+        virtual void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  ) = 0;
+
+        // Set Size - usually the number of data items to be processed, see ExecuteRange. Defaults to 1
+        uint32_t     m_SetSize  = 1;
+
+        // Min Range - Minimum size of of TaskSetPartition range when splitting a task set into partitions.
+        // Designed for reducing scheduling overhead by preventing set being
+        // divided up too small. Ranges passed to ExecuteRange will *not* be a mulitple of this,
+        // only attempts to deliver range sizes larger than this most of the time.
+        // This should be set to a value which results in computation effort of at least 10k
+        // clock cycles to minimize task scheduler overhead.
+        // NOTE: The last partition will be smaller than m_MinRange if m_SetSize is not a multiple
+        // of m_MinRange.
+        // Also known as grain size in literature.
+        uint32_t     m_MinRange  = 1;
+
+    private:
+        friend class TaskScheduler;
+        void         OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ ) override final;
+        uint32_t     m_RangeToRun = 1;
+    };
+
+    // Subclass IPinnedTask to create tasks which can be run on a given thread only.
+    class IPinnedTask : public ICompletable
+    {
+    public:
+        IPinnedTask() = default;
+        IPinnedTask( uint32_t threadNum_ ) : threadNum(threadNum_) {}  // default is to run a task on main thread
+
+        // IPinnedTask needs to be non abstract for intrusive list functionality.
+        // Should never be called as should be overridden.
+        virtual void Execute() { ENKI_ASSERT(false); }
+
+        uint32_t                  threadNum = 0; // thread to run this pinned task on
+        std::atomic<IPinnedTask*> pNext = {NULL};
+    private:
+        void         OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ ) override final;
+    };
+
+    // TaskSet - a utility task set for creating tasks based on std::func.
+    typedef std::function<void (TaskSetPartition range, uint32_t threadnum  )> TaskSetFunction;
+    class TaskSet : public ITaskSet
+    {
+    public:
+        TaskSet() = default;
+        TaskSet( TaskSetFunction func_ ) : m_Function( func_ ) {}
+        TaskSet( uint32_t setSize_, TaskSetFunction func_ ) : ITaskSet( setSize_ ), m_Function( func_ ) {}
+
+        void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  ) override { m_Function( range_, threadnum_ ); }
+        TaskSetFunction m_Function;
+    };
+
+    // LambdaPinnedTask - a utility pinned task for creating tasks based on std::func.
+    typedef std::function<void ()> PinnedTaskFunction;
+    class LambdaPinnedTask : public IPinnedTask
+    {
+    public:
+        LambdaPinnedTask() = default;
+        LambdaPinnedTask( PinnedTaskFunction func_ ) : m_Function( func_ ) {}
+        LambdaPinnedTask( uint32_t threadNum_, PinnedTaskFunction func_ ) : IPinnedTask( threadNum_ ), m_Function( func_ ) {}
+
+        void Execute() override { m_Function(); }
+        PinnedTaskFunction m_Function;
+    };
+
+    class Dependency
+    {
+    public:
+                        Dependency() = default; 
+                        Dependency( const Dependency& ) = delete;
+        ENKITS_API      Dependency( Dependency&& ) noexcept;	
+        ENKITS_API      Dependency(    const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ );
+        ENKITS_API      ~Dependency();
+
+        ENKITS_API void SetDependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ );
+        ENKITS_API void ClearDependency();
+              ICompletable* GetTaskToRunOnCompletion() { return pTaskToRunOnCompletion; }
+        const ICompletable* GetDependencyTask()        { return pDependencyTask; }
+    private:
+        friend class TaskScheduler; friend class ICompletable;
+        ICompletable*       pTaskToRunOnCompletion = NULL;
+        const ICompletable* pDependencyTask        = NULL;
+        Dependency*         pNext                  = NULL;
+    };
+
+    // TaskScheduler implements several callbacks intended for profilers
+    typedef void (*ProfilerCallbackFunc)( uint32_t threadnum_ );
+    struct ProfilerCallbacks
+    {
+        ProfilerCallbackFunc threadStart;
+        ProfilerCallbackFunc threadStop;
+        ProfilerCallbackFunc waitForNewTaskSuspendStart;      // thread suspended waiting for new tasks
+        ProfilerCallbackFunc waitForNewTaskSuspendStop;       // thread unsuspended
+        ProfilerCallbackFunc waitForTaskCompleteStart;        // thread waiting for task completion
+        ProfilerCallbackFunc waitForTaskCompleteStop;         // thread stopped waiting
+        ProfilerCallbackFunc waitForTaskCompleteSuspendStart; // thread suspended waiting task completion
+        ProfilerCallbackFunc waitForTaskCompleteSuspendStop;  // thread unsuspended
+    };
+
+    // Custom allocator, set in TaskSchedulerConfig. Also see ENKI_CUSTOM_ALLOC_FILE_AND_LINE for file_ and line_
+    typedef void* (*AllocFunc)( size_t align_, size_t size_, void* userData_, const char* file_, int line_ );
+    typedef void  (*FreeFunc)(  void* ptr_,    size_t size_, void* userData_, const char* file_, int line_ );
+    ENKITS_API void* DefaultAllocFunc(  size_t align_, size_t size_, void* userData_, const char* file_, int line_ );
+    ENKITS_API void  DefaultFreeFunc(   void* ptr_,    size_t size_, void* userData_, const char* file_, int line_ );
+    struct CustomAllocator
+    {
+        AllocFunc alloc    = DefaultAllocFunc;
+        FreeFunc  free     = DefaultFreeFunc;
+        void*     userData = nullptr;
+    };
+
+    // TaskSchedulerConfig - configuration struct for advanced Initialize
+    struct TaskSchedulerConfig
+    {
+        // numTaskThreadsToCreate - Number of tasking threads the task scheduler will create. Must be > 0.
+        // Defaults to GetNumHardwareThreads()-1 threads as thread which calls initialize is thread 0.
+        uint32_t          numTaskThreadsToCreate = GetNumHardwareThreads()-1;
+
+        // numExternalTaskThreads - Advanced use. Number of external threads which need to use TaskScheduler API.
+        // See TaskScheduler::RegisterExternalTaskThread() for usage.
+        // Defaults to 0. The thread used to initialize the TaskScheduler can also use the TaskScheduler API.
+        // Thus there are (numTaskThreadsToCreate + numExternalTaskThreads + 1) able to use the API, with this
+        // defaulting to the number of harware threads available to the system.
+        uint32_t          numExternalTaskThreads = 0;
+
+        ProfilerCallbacks profilerCallbacks = {};
+
+        CustomAllocator   customAllocator;
+    };
+
+    class TaskScheduler
+    {
+    public:
+        ENKITS_API TaskScheduler();
+        ENKITS_API ~TaskScheduler();
+
+        // Call an Initialize function before adding tasks.
+
+        // Initialize() will create GetNumHardwareThreads()-1 tasking threads, which is
+        // sufficient to fill the system when including the main thread.
+        // Initialize can be called multiple times - it will wait for completion
+        // before re-initializing.
+        ENKITS_API void            Initialize();
+
+        // Initialize( numThreadsTotal_ )
+        // will create numThreadsTotal_-1 threads, as thread 0 is
+        // the thread on which the initialize was called.
+        // numThreadsTotal_ must be > 0
+        ENKITS_API void            Initialize( uint32_t numThreadsTotal_ );
+
+        // Initialize with advanced TaskSchedulerConfig settings. See TaskSchedulerConfig.
+        ENKITS_API void            Initialize( TaskSchedulerConfig config_ );
+
+        // Get config. Can be called before Initialize to get the defaults.
+        ENKITS_API TaskSchedulerConfig GetConfig() const;
+
+        // while( !GetIsShutdownRequested() ) {} can be used in tasks which loop, to check if enkiTS has been requested to shutdown.
+        // If GetIsShutdownRequested() returns true should then exit. Not required for finite tasks
+        // Safe to use with WaitforAllAndShutdown() and ShutdownNow() where this will be set
+        // Not safe to use with WaitforAll(). 
+        inline     bool            GetIsShutdownRequested() const { return m_bShutdownRequested.load( std::memory_order_acquire ); }
+
+        // while( !GetIsWaitforAllCalled() ) {} can be used in tasks which loop, to check if WaitforAll() has been called.
+        // If GetIsWaitforAllCalled() returns false should then exit. Not required for finite tasks
+        // This is intended to be used with code which calls WaitforAll() with flag WAITFORALLFLAGS_INC_WAIT_NEW_PINNED_TASKS set.
+        // This is also set when the the task manager is shutting down, so no need to have an additional check for GetIsShutdownRequested()
+        inline     bool            GetIsWaitforAllCalled() const { return m_bWaitforAllCalled.load( std::memory_order_acquire ); }
+
+        // Adds the TaskSet to pipe and returns if the pipe is not full.
+        // If the pipe is full, pTaskSet is run.
+        // should only be called from main thread, or within a task
+        ENKITS_API void            AddTaskSetToPipe( ITaskSet* pTaskSet_ );
+
+        // Thread 0 is main thread, otherwise use threadNum
+        // Pinned tasks can be added from any thread
+        ENKITS_API void            AddPinnedTask( IPinnedTask* pTask_ );
+
+        // This function will run any IPinnedTask* for current thread, but not run other
+        // Main thread should call this or use a wait to ensure it's tasks are run.
+        ENKITS_API void            RunPinnedTasks();
+
+        // Runs the TaskSets in pipe until true == pTaskSet->GetIsComplete();
+        // should only be called from thread which created the taskscheduler , or within a task
+        // if called with 0 it will try to run tasks, and return if none available.
+        // To run only a subset of tasks, set priorityOfLowestToRun_ to a high priority.
+        // Default is lowest priority available.
+        // Only wait for child tasks of the current task otherwise a deadlock could occur.
+        // WaitforTask will exit if ShutdownNow() is called even if pCompletable_ is not complete
+        ENKITS_API void            WaitforTask( const ICompletable* pCompletable_, enki::TaskPriority priorityOfLowestToRun_ = TaskPriority(TASK_PRIORITY_NUM - 1) );
+
+        // Waits for all task sets to complete - not guaranteed to work unless we know we
+        // are in a situation where tasks aren't being continuously added.
+        // If you are running tasks which loop, make sure to check GetIsWaitforAllCalled() and exit
+        // WaitfoAll will exit if ShutdownNow() is called even if there are still tasks to run or currently running
+        ENKITS_API void            WaitforAll();
+
+        // Waits for all task sets to complete and shutdown threads - not guaranteed to work unless we know we
+        // are in a situation where tasks aren't being continuously added.
+        // This function can be safely called even if TaskScheduler::Initialize() has not been called.
+        ENKITS_API void            WaitforAllAndShutdown();
+
+        // Shutdown threads without waiting for all tasks to complete.
+        // Intended to be used to exit an application quickly.
+        // This function can be safely called even if TaskScheduler::Initialize() has not been called.
+        // This function will still wait for any running tasks to exit before the task threads exit.
+        // ShutdownNow will cause tasks which have been added to the scheduler but not completed
+        // to be in an undefined state in which should not be re-launched.
+        ENKITS_API void            ShutdownNow();
+
+        // Waits for the current thread to receive a PinnedTask
+        // Will not run any tasks - use with RunPinnedTasks()
+        // Can be used with both ExternalTaskThreads or with an enkiTS tasking thread to create
+        // a thread which only runs pinned tasks. If enkiTS threads are used can create
+        // extra enkiTS task threads to handle non blocking computation via normal tasks.
+        ENKITS_API void            WaitForNewPinnedTasks();
+
+        // Returns the number of threads created for running tasks + number of external threads
+        // plus 1 to account for the thread used to initialize the task scheduler.
+        // Equivalent to config values: numTaskThreadsToCreate + numExternalTaskThreads + 1.
+        // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
+        ENKITS_API uint32_t        GetNumTaskThreads() const;
+
+        // Returns the current task threadNum
+        // Will return 0 for thread which initialized the task scheduler,
+        // and all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
+        // and < GetNumTaskThreads() for all threads.
+        // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
+        ENKITS_API uint32_t        GetThreadNum() const;
+
+         // Call on a thread to register the thread to use the TaskScheduling API.
+        // This is implicitly done for the thread which initializes the TaskScheduler
+        // Intended for developers who have threads who need to call the TaskScheduler API
+        // Returns true if successfull, false if not.
+        // Can only have numExternalTaskThreads registered at any one time, which must be set
+        // at initialization time.
+        ENKITS_API bool            RegisterExternalTaskThread();
+
+        // As RegisterExternalTaskThread() but explicitly requests a given thread number.
+        // threadNumToRegister_ must be  >= GetNumFirstExternalTaskThread()
+        // and < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads )
+        ENKITS_API bool            RegisterExternalTaskThread( uint32_t threadNumToRegister_ );
+
+        // Call on a thread on which RegisterExternalTaskThread has been called to deregister that thread.
+        ENKITS_API void            DeRegisterExternalTaskThread();
+
+        // Get the number of registered external task threads.
+        ENKITS_API uint32_t        GetNumRegisteredExternalTaskThreads();
+
+        // Get the thread number of the first external task thread. This thread
+        // is not guaranteed to be registered, but threads are registered in order
+        // from GetNumFirstExternalTaskThread() up to ( GetNumFirstExternalTaskThread() + numExternalTaskThreads )
+        // Note that if numExternalTaskThreads == 0 a for loop using this will be valid:
+        // for( uint32_t externalThreadNum = GetNumFirstExternalTaskThread();
+        //      externalThreadNum < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads
+        //      ++externalThreadNum ) { // do something with externalThreadNum }
+        inline static constexpr uint32_t  GetNumFirstExternalTaskThread() { return 1; }
+
+        // ------------- Start DEPRECATED Functions -------------
+        // DEPRECATED: use GetIsShutdownRequested() instead of GetIsRunning() in external code
+        // while( GetIsRunning() ) {} can be used in tasks which loop, to check if enkiTS has been shutdown.
+        // If GetIsRunning() returns false should then exit. Not required for finite tasks
+        inline     bool            GetIsRunning() const { return m_bRunning.load( std::memory_order_acquire ); }
+
+        // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask
+        inline void                WaitforTaskSet( const ICompletable* pCompletable_ ) { WaitforTask( pCompletable_ ); }
+
+        // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead
+        // Returns the ProfilerCallbacks structure so that it can be modified to
+        // set the callbacks. Should be set prior to initialization.
+        inline ProfilerCallbacks* GetProfilerCallbacks() { return &m_Config.profilerCallbacks; }
+        // -------------  End DEPRECATED Functions  -------------
+
+    private:
+        friend class ICompletable; friend class ITaskSet; friend class IPinnedTask;
+        static void TaskingThreadFunction( const ThreadArgs& args_ );
+        bool        HaveTasks( uint32_t threadNum_ );
+        void        WaitForNewTasks( uint32_t threadNum_ );
+        void        WaitForTaskCompletion( const ICompletable* pCompletable_, uint32_t threadNum_ );
+        void        RunPinnedTasks( uint32_t threadNum_, uint32_t priority_ );
+        bool        TryRunTask( uint32_t threadNum_, uint32_t& hintPipeToCheck_io_ );
+        bool        TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_t& hintPipeToCheck_io_ );
+        void        StartThreads();
+        void        StopThreads( bool bWait_ );
+        void        SplitAndAddTask( uint32_t threadNum_, SubTaskSet subTask_, uint32_t rangeToSplit_ );
+        void        WakeThreadsForNewTasks();
+        void        WakeThreadsForTaskCompletion();
+        bool        WakeSuspendedThreadsWithPinnedTasks();
+        void        InitDependencies( ICompletable* pCompletable_  );
+        ENKITS_API void TaskComplete( ICompletable* pTask_, bool bWakeThreads_, uint32_t threadNum_ );
+        ENKITS_API void AddTaskSetToPipeInt( ITaskSet* pTaskSet_, uint32_t threadNum_ );
+        ENKITS_API void AddPinnedTaskInt( IPinnedTask* pTask_ );
+
+        template< typename T > T*   NewArray( size_t num_, const char* file_, int line_  );
+        template< typename T > void DeleteArray( T* p_, size_t num_, const char* file_, int line_ );
+        template<class T, class... Args> T* New( const char* file_, int line_,  Args&&... args_ );
+        template< typename T > void Delete( T* p_, const char* file_, int line_ );
+        template< typename T > T*   Alloc( const char* file_, int line_ );
+        template< typename T > void Free( T* p_, const char* file_, int line_ );
+        semaphoreid_t* SemaphoreNew();
+        void SemaphoreDelete( semaphoreid_t* pSemaphore_ );
+
+        TaskPipe*              m_pPipesPerThread[ TASK_PRIORITY_NUM ];
+        PinnedTaskList*        m_pPinnedTaskListPerThread[ TASK_PRIORITY_NUM ];
+
+        uint32_t               m_NumThreads;
+        ThreadDataStore*       m_pThreadDataStore;
+        std::thread*           m_pThreads;
+        std::atomic<bool>      m_bRunning;
+        std::atomic<bool>      m_bShutdownRequested;
+        std::atomic<bool>      m_bWaitforAllCalled;
+        std::atomic<int32_t>   m_NumInternalTaskThreadsRunning;
+        std::atomic<int32_t>   m_NumThreadsWaitingForNewTasks;
+        std::atomic<int32_t>   m_NumThreadsWaitingForTaskCompletion;
+        uint32_t               m_NumPartitions;
+        semaphoreid_t*         m_pNewTaskSemaphore;
+        semaphoreid_t*         m_pTaskCompleteSemaphore;
+        uint32_t               m_NumInitialPartitions;
+        bool                   m_bHaveThreads;
+        TaskSchedulerConfig    m_Config;
+        std::atomic<int32_t>   m_NumExternalTaskThreadsRegistered;
+
+        TaskScheduler( const TaskScheduler& nocopy_ );
+        TaskScheduler& operator=( const TaskScheduler& nocopy_ );
+
+    protected:
+        void SetCustomAllocator( CustomAllocator customAllocator_ ); // for C interface
+    };
+
+    inline void ICompletable::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
+    {
+        m_RunningCount.fetch_sub( 1, std::memory_order_release );
+        pTaskScheduler_->TaskComplete( this, true, threadNum_ );
+    }
+
+    inline void ITaskSet::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
+    {
+        pTaskScheduler_->AddTaskSetToPipeInt( this, threadNum_ );
+    }
+
+    inline void IPinnedTask::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
+    {
+        (void)threadNum_;
+        pTaskScheduler_->AddPinnedTaskInt( this );
+    }
+
+    inline ICompletable::~ICompletable()
+    {
+        ENKI_ASSERT( GetIsComplete() ); // this task is still waiting to run
+        Dependency* pDependency = m_pDependents;
+        while( pDependency )
+        {
+            Dependency* pNext = pDependency->pNext;
+            pDependency->pDependencyTask = NULL;
+            pDependency->pNext = NULL;
+            pDependency = pNext;
+        }
+    }
+
+    inline void ICompletable::SetDependency( Dependency& dependency_, const ICompletable* pDependencyTask_ )
+    {
+        ENKI_ASSERT( pDependencyTask_ != this );
+        dependency_.SetDependency( pDependencyTask_, this );
+    }
+
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D& dependencyArray_ , const T(&taskArray_)[SIZE] ) {
+        static_assert( std::tuple_size<D>::value >= SIZE, "Size of dependency array too small" );
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyArray_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+    template<typename D, typename T>
+    void ICompletable::SetDependenciesArr( D& dependencyArray_, std::initializer_list<T*> taskpList_ ) {
+        ENKI_ASSERT( std::tuple_size<D>::value >= taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyArray_[i++].SetDependency( pTask, this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D(&dependencyArray_)[SIZE], const T(&taskArray_)[SIZE] ) {
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyArray_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D(&dependencyArray_)[SIZE], std::initializer_list<T*> taskpList_ ) {
+        ENKI_ASSERT( SIZE >= taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyArray_[i++].SetDependency( pTask, this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesVec( D& dependencyVec_, const T(&taskArray_)[SIZE] ) {
+        dependencyVec_.resize( SIZE );
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyVec_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+
+    template<typename D, typename T>
+    void ICompletable::SetDependenciesVec( D& dependencyVec_, std::initializer_list<T*> taskpList_ ) {
+        dependencyVec_.resize( taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyVec_[i++].SetDependency( pTask, this );
+        }
+    }
+}

--- a/Source/ThirdParty/enkiTS/src/TaskScheduler.h
+++ b/Source/ThirdParty/enkiTS/src/TaskScheduler.h
@@ -76,6 +76,8 @@ namespace enki
     struct SubTaskSet;
     struct semaphoreid_t;
 
+    static constexpr uint32_t NO_THREAD_NUM = 0xFFFFFFFF;
+
     ENKITS_API uint32_t GetNumHardwareThreads();
 
     enum TaskPriority
@@ -380,9 +382,9 @@ namespace enki
 
         // Returns the current task threadNum
         // Will return 0 for thread which initialized the task scheduler,
-        // and all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
-        // and < GetNumTaskThreads() for all threads.
-        // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
+        // and NO_THREAD_NUM for all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
+        // and < GetNumTaskThreads() for all registered and internal enkiTS threads.
+        // It is guaranteed that GetThreadNum() < GetNumTaskThreads() unless it is NO_THREAD_NUM
         ENKITS_API uint32_t        GetThreadNum() const;
 
          // Call on a thread to register the thread to use the TaskScheduling API.

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -214,6 +214,7 @@ set (THIRD_PARTY_DEPENDENCIES
     spirv-cross-msl
     spirv-cross-hlsl
     tinygltf
+    enkiTS
 )
 
 if (URHO3D_MERGE_STATIC_LIBS)

--- a/Source/Urho3D/CSharp/Swig/Urho3D.i
+++ b/Source/Urho3D/CSharp/Swig/Urho3D.i
@@ -595,10 +595,8 @@ public:
 %ignore Urho3D::PointOctreeQuery::TestDrawables;
 %ignore Urho3D::BoxOctreeQuery::TestDrawables;
 %ignore Urho3D::OctreeQuery::TestDrawables;
-%ignore Urho3D::UpdateDrawablesWork;
 %ignore Urho3D::ProcessLightWork;
 %ignore Urho3D::CheckVisibilityWork;
-%ignore Urho3D::CheckDrawableVisibilityWork;
 %ignore Urho3D::ELEMENT_TYPESIZES;
 %ignore Urho3D::ScratchBuffer;
 %ignore Urho3D::Drawable::batches_;

--- a/Source/Urho3D/CSharp/Swig/generated/Urho3D/_pre_core.i
+++ b/Source/Urho3D/CSharp/Swig/generated/Urho3D/_pre_core.i
@@ -122,10 +122,6 @@ using AttributeModeFlags = Urho3D::AttributeMode;
 %csattribute(Urho3D::Time, %arg(unsigned int), TimerPeriod, GetTimerPeriod, SetTimerPeriod);
 %csattribute(Urho3D::Time, %arg(float), ElapsedTime, GetElapsedTime);
 %csattribute(Urho3D::Time, %arg(float), FramesPerSecond, GetFramesPerSecond);
-%csattribute(Urho3D::WorkQueue, %arg(SharedPtr<Urho3D::WorkItem>), FreeItem, GetFreeItem);
-%csattribute(Urho3D::WorkQueue, %arg(unsigned int), NumThreads, GetNumThreads);
-%csattribute(Urho3D::WorkQueue, %arg(bool), IsCompleting, IsCompleting);
-%csattribute(Urho3D::WorkQueue, %arg(int), Tolerance, GetTolerance, SetTolerance);
 %csattribute(Urho3D::WorkQueue, %arg(int), NonThreadedWorkMs, GetNonThreadedWorkMs, SetNonThreadedWorkMs);
 %pragma(csharp) moduleimports=%{
 public static partial class E

--- a/Source/Urho3D/Core/WorkQueue.cpp
+++ b/Source/Urho3D/Core/WorkQueue.cpp
@@ -20,131 +20,509 @@
 // THE SOFTWARE.
 //
 
-#include "../Precompiled.h"
+#include "Urho3D/Precompiled.h"
 
-#include "../Core/CoreEvents.h"
-#include "../Core/ProcessUtils.h"
-#include "../Core/Profiler.h"
-#include "../Core/Thread.h"
-#include "../Core/Timer.h"
-#include "../Core/WorkQueue.h"
-#include "../IO/Log.h"
+#include "Urho3D/Core/WorkQueue.h"
+
+#include "Urho3D/Core/CoreEvents.h"
+#include "Urho3D/Core/ProcessUtils.h"
+#include "Urho3D/Core/Profiler.h"
+#include "Urho3D/Core/Thread.h"
+#include "Urho3D/Core/Timer.h"
+#include "Urho3D/IO/Log.h"
+
+#ifdef URHO3D_THREADING
+#include <enkiTS/src/TaskScheduler.h>
+#endif
 
 namespace Urho3D
 {
 
-/// Thread index.
-static thread_local unsigned currentThreadIndex = M_MAX_UNSIGNED;
-static unsigned maxThreadIndex = 1;
+namespace
+{
 
-/// Worker thread managed by the work queue.
-class WorkerThread : public Thread, public RefCounted
+// Context and WorkQueue are singletons anyway, keep the values here for quick access
+unsigned threadIndexCount{};
+WorkQueue* workQueue{};
+
+#ifdef URHO3D_THREADING
+template <class T>
+struct ReleaseInternalTask : enki::ICompletable
+{
+    enki::Dependency dependency_;
+
+    void OnDependenciesComplete(enki::TaskScheduler* taskScheduler, uint32_t threadNum) override
+    {
+        enki::ICompletable::OnDependenciesComplete(taskScheduler, threadNum);
+
+        auto task = const_cast<T*>(static_cast<const T*>(dependency_.GetDependencyTask()));
+        task->Release();
+    }
+};
+#endif
+
+TaskPriority ConvertLegacyPriority(unsigned priority)
+{
+    return priority == M_MAX_UNSIGNED
+        ? TaskPriority::Immediate
+        : static_cast<TaskPriority>(static_cast<unsigned>(TaskPriority::Low) - ea::min(priority, 2u));
+}
+
+}
+
+#ifdef URHO3D_THREADING
+
+template <class T> WorkQueue::TaskPool<T>::TaskPool()
+{
+}
+
+template <class T> WorkQueue::TaskPool<T>::~TaskPool()
+{
+}
+
+template <class T> T* WorkQueue::TaskPool<T>::Allocate()
+{
+    MutexLock lock(mutex_);
+
+    if (freeItems_.empty())
+    {
+        pool_.push_back(ea::make_unique<T>(this));
+        return pool_.back().get();
+    }
+    else
+    {
+        T* item = freeItems_.back();
+        freeItems_.pop_back();
+        return item;
+    }
+}
+
+template <class T> void WorkQueue::TaskPool<T>::Release(T* item)
+{
+    MutexLock lock(mutex_);
+    freeItems_.push_back(item);
+}
+
+template <class T> unsigned WorkQueue::TaskPool<T>::GetNumUsed() const
+{
+    MutexLock lock(mutex_);
+    return pool_.size() - freeItems_.size();
+}
+
+template <class T> WorkQueue::TaskStack<T>::TaskStack()
+{
+}
+
+template <class T> WorkQueue::TaskStack<T>::~TaskStack()
+{
+}
+
+template <class T> WorkQueue::TaskStack<T>::TaskStack(TaskStack<T>&& other)
+    : pool_(ea::move(other.pool_))
+{
+}
+
+template <class T> WorkQueue::TaskStack<T>& WorkQueue::TaskStack<T>::operator=(TaskStack<T>&& other)
+{
+    pool_ = ea::move(other.pool_);
+    return *this;
+}
+
+template <class T> T* WorkQueue::TaskStack<T>::Allocate()
+{
+    if (nextFreeIndex_ == pool_.size())
+    {
+        ++nextFreeIndex_;
+        pool_.push_back(ea::make_unique<T>());
+        return pool_.back().get();
+    }
+    else
+    {
+        return pool_[nextFreeIndex_++].get();
+    }
+}
+
+template <class T> void WorkQueue::TaskStack<T>::Purge()
+{
+    nextFreeIndex_ = 0;
+}
+
+class WorkQueue::InternalTaskInPool : public enki::ITaskSet
 {
 public:
-    /// Construct.
-    WorkerThread(WorkQueue* owner, unsigned index) :
-        owner_(owner),
-        index_(index)
+    TaskFunction function_;
+
+    InternalTaskInPool(TaskPool<InternalTaskInPool>* owner)
+        : owner_(owner)
     {
+        releaser_.SetDependency(releaser_.dependency_, this);
     }
 
-    /// Process work items until stopped.
-    void ThreadFunction() override
+    void Release()
     {
-        URHO3D_PROFILE_THREAD(Format("WorkerThread {}", (uint64_t)GetCurrentThreadID()).c_str());
-        currentThreadIndex = index_;
-        // Init FPU state first
-        InitFPU();
-        owner_->ProcessItems(index_);
+        owner_->Release(this);
     }
 
-    /// Return thread index.
-    unsigned GetIndex() const { return index_; }
+    void ExecuteRange(enki::TaskSetPartition range, uint32_t threadNum) override
+    {
+        URHO3D_ASSERT(function_);
+        function_(threadNum, workQueue);
+        function_ = nullptr;
+    }
 
 private:
-    /// Work queue.
-    WorkQueue* owner_;
-    /// Thread index.
-    unsigned index_;
+    TaskPool<InternalTaskInPool>* owner_{};
+    ReleaseInternalTask<InternalTaskInPool> releaser_;
 };
 
-WorkQueue::WorkQueue(Context* context) :
-    Object(context),
-    shutDown_(false),
-    pausing_(false),
-    paused_(false),
-    completing_(false),
-    tolerance_(10),
-    lastSize_(0),
-    maxNonThreadedWorkMs_(5)
+class WorkQueue::InternalPinnedTaskInPool : public enki::IPinnedTask
 {
-    currentThreadIndex = 0;
-    maxThreadIndex = 1;
-    mainThreadTasks_.Clear();
-    SubscribeToEvent(E_BEGINFRAME, URHO3D_HANDLER(WorkQueue, HandleBeginFrame));
+public:
+    TaskFunction function_;
+
+    InternalPinnedTaskInPool(TaskPool<InternalPinnedTaskInPool>* owner)
+        : owner_(owner)
+    {
+        releaser_.SetDependency(releaser_.dependency_, this);
+    }
+
+    void Release()
+    {
+        owner_->Release(this);
+    }
+
+    void Execute() override
+    {
+        URHO3D_ASSERT(function_);
+        function_(threadNum, workQueue);
+        function_ = nullptr;
+    }
+
+private:
+    TaskPool<InternalPinnedTaskInPool>* owner_{};
+    ReleaseInternalTask<InternalPinnedTaskInPool> releaser_;
+};
+
+class WorkQueue::InternalTaskInStack : public enki::ITaskSet
+{
+public:
+    TaskFunction function_;
+    enki::Dependency observerDependency_;
+
+    void ExecuteRange(enki::TaskSetPartition range, uint32_t threadNum) override
+    {
+        URHO3D_ASSERT(function_);
+        function_(threadNum, workQueue);
+        function_ = nullptr;
+    }
+};
+
+class WorkQueue::InternalPinnedTaskInStack : public enki::IPinnedTask
+{
+public:
+    TaskFunction function_;
+    enki::Dependency observerDependency_;
+
+    void Execute() override
+    {
+        URHO3D_ASSERT(function_);
+        function_(threadNum, workQueue);
+        function_ = nullptr;
+    }
+};
+
+class WorkQueue::TaskCompletionObserver
+    : public enki::ITaskSet
+    , public MovableNonCopyable
+{
+public:
+    TaskCompletionObserver() = default;
+
+    void AddDependency(InternalTaskInStack* internalTask)
+    {
+        SetDependency(internalTask->observerDependency_, internalTask);
+    }
+
+    void ExecuteRange(enki::TaskSetPartition range, uint32_t threadNum) override
+    {
+    }
+};
+
+#endif
+
+WorkQueue::WorkQueue(Context* context)
+    : Object(context)
+{
+    if (workQueue == nullptr)
+    {
+        threadIndexCount = 1;
+        workQueue = this;
+    }
+
+    SubscribeToEvent(E_BEGINFRAME, [this](StringHash, VariantMap&) { Update(); });
 }
 
 WorkQueue::~WorkQueue()
 {
-    // Stop the worker threads. First make sure they are not waiting for work items
-    shutDown_ = true;
-    Resume();
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+    {
+        taskScheduler_->ShutdownNow();
+        taskScheduler_ = nullptr;
+    }
+#endif
 
-    for (unsigned i = 0; i < threads_.size(); ++i)
-        threads_[i]->Stop();
+    if (workQueue == this)
+    {
+        threadIndexCount = 0;
+        workQueue = nullptr;
+    }
 }
 
-void WorkQueue::CreateThreads(unsigned numThreads)
+void WorkQueue::Initialize(unsigned numThreads)
 {
-#ifdef URHO3D_THREADING
     // Other subsystems may initialize themselves according to the number of threads.
     // Therefore allow creating the threads only once, after which the amount is fixed
-    if (!threads_.empty())
+    if (numProcessingThreads_ > 0)
         return;
 
-    // Start threads in paused mode
-    Pause();
+    numProcessingThreads_ = numThreads + 1;
+    threadIndexCount = 1;
 
-    maxThreadIndex = numThreads + 1;
-    for (unsigned i = 0; i < numThreads; ++i)
+#ifdef URHO3D_THREADING
+    if (numThreads > 0)
     {
-        SharedPtr<WorkerThread> thread(new WorkerThread(this, i + 1));
-        thread->SetName(Format("Worker {}", i + 1));
-        thread->Run();
-        threads_.push_back(thread);
+        taskScheduler_ = ea::make_unique<enki::TaskScheduler>();
+        taskScheduler_->Initialize(numProcessingThreads_);
+
+        threadIndexCount = taskScheduler_->GetNumTaskThreads();
+
+        localTaskStack_.resize(threadIndexCount);
+        localPinnedTaskStack_.resize(threadIndexCount);
+        pendingImmediateTasks_.resize(threadIndexCount);
+
+        URHO3D_LOGINFO("Created {} worker thread{}", numThreads, numThreads > 1 ? "s" : "");
     }
-    mainThreadTasks_.Clear();
-#else
-    URHO3D_LOGERROR("Can not create worker threads as threading is disabled");
 #endif
 }
 
-void WorkQueue::CallFromMainThread(WorkFunction workFunction)
+void WorkQueue::Update()
 {
-    if (GetThreadIndex() == 0)
+    ProcessPostedTasks();
+    ProcessMainThreadTasks();
+}
+
+void WorkQueue::ProcessPostedTasks()
+{
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
     {
-        workFunction(0);
+        CompleteImmediateForThisThread();
+        taskScheduler_->RunPinnedTasks();
+        for (auto& stack : localTaskStack_)
+            stack.Purge();
+        for (auto& stack : localPinnedTaskStack_)
+            stack.Purge();
+    }
+#endif
+
+    if (!fallbackTaskQueue_.empty())
+    {
+        HiresTimer timer;
+        for (auto& [_, task] : fallbackTaskQueue_)
+        {
+            if (timer.GetUSec(false) >= maxNonThreadedWorkMs_ * 1000LL)
+                break;
+
+            task(0, this);
+            task = nullptr;
+        }
+        PurgeProcessedTasksInFallbackQueue();
+    }
+}
+
+void WorkQueue::ProcessMainThreadTasks()
+{
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+        taskScheduler_->RunPinnedTasks();
+#endif
+
+    {
+        MutexLock lock(mainThreadTasksMutex_);
+        ea::swap(mainThreadTasks_, mainThreadTasksSwap_);
+    }
+
+    for (const auto& callback : mainThreadTasksSwap_)
+        callback(0, this);
+    mainThreadTasksSwap_.clear();
+}
+
+void WorkQueue::PurgeProcessedTasksInFallbackQueue()
+{
+    ea::erase_if(fallbackTaskQueue_,
+        [](const ea::pair<TaskPriority, TaskFunction>& priorityAndTask) { return !priorityAndTask.second; });
+}
+
+#ifdef URHO3D_THREADING
+template <class T> void WorkQueue::SetupInternalTask(T* internalTask, TaskFunction&& task, TaskPriority priority)
+{
+    internalTask->function_ = ea::move(task);
+    internalTask->m_Priority = static_cast<enki::TaskPriority>(priority);
+}
+#endif
+
+void WorkQueue::PostTask(TaskFunction&& task, TaskPriority priority)
+{
+    if (!IsProcessingThread())
+    {
+        auto wrappedTask = [task = ea::move(task), priority](unsigned, WorkQueue* queue) mutable
+        { queue->PostTask(ea::move(task), priority); };
+
+        PostTaskForMainThread(ea::move(wrappedTask), priority);
         return;
     }
 
-    mainThreadTasks_.Insert(ea::move(workFunction));
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+    {
+        if (priority == TaskPriority::Immediate)
+        {
+            const unsigned threadIndex = GetThreadIndex();
+            InternalTaskInStack* internalTask = localTaskStack_[threadIndex].Allocate();
+            SetupInternalTask(internalTask, ea::move(task), priority);
+            pendingImmediateTasks_[threadIndex].push_back(internalTask);
+        }
+        else
+        {
+            InternalTaskInPool* internalTask = globalTaskPool_.Allocate();
+            SetupInternalTask(internalTask, ea::move(task), priority);
+            taskScheduler_->AddTaskSetToPipe(internalTask);
+        }
+        return;
+    }
+#endif
+
+    if (priority == TaskPriority::Immediate)
+        task(0, this);
+    else
+        fallbackTaskQueue_.emplace_back(priority, ea::move(task));
+}
+
+void WorkQueue::PostTaskForThread(TaskFunction&& task, TaskPriority priority, unsigned threadIndex)
+{
+    if (!IsProcessingThread())
+    {
+        auto wrappedTask = [task = ea::move(task), priority, threadIndex](unsigned, WorkQueue* queue) mutable
+        { queue->PostTaskForThread(ea::move(task), priority, threadIndex); };
+
+        PostTaskForMainThread(ea::move(wrappedTask), priority);
+        return;
+    }
+
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+    {
+        if (priority == TaskPriority::Immediate)
+        {
+            InternalPinnedTaskInStack* internalTask = localPinnedTaskStack_[GetThreadIndex()].Allocate();
+            SetupInternalTask(internalTask, ea::move(task), priority);
+            internalTask->threadNum = threadIndex;
+            taskScheduler_->AddPinnedTask(internalTask);
+        }
+        else
+        {
+            InternalPinnedTaskInPool* internalTask = globalPinnedTaskPool_.Allocate();
+            SetupInternalTask(internalTask, ea::move(task), priority);
+            internalTask->threadNum = threadIndex;
+            taskScheduler_->AddPinnedTask(internalTask);
+        }
+        return;
+    }
+#endif
+
+    if (priority == TaskPriority::Immediate)
+        task(0, this);
+    else
+        fallbackTaskQueue_.emplace_back(priority, ea::move(task));
+}
+
+void WorkQueue::PostTaskForMainThread(TaskFunction&& task, TaskPriority priority)
+{
+#ifdef URHO3D_THREADING
+    if (taskScheduler_ && IsProcessingThread())
+    {
+        PostTaskForThread(ea::move(task), priority, 0);
+        return;
+    }
+#endif
+
+    if (Thread::IsMainThread())
+        task(0, this);
+    else
+    {
+        MutexLock lock(mainThreadTasksMutex_);
+        mainThreadTasks_.push_back(ea::move(task));
+    }
+}
+
+void WorkQueue::CompleteImmediateForAnotherThread(unsigned threadIndex)
+{
+#ifdef URHO3D_THREADING
+    static const auto priority = static_cast<enki::TaskPriority>(TaskPriority::Immediate);
+    if (taskScheduler_)
+    {
+        auto& pendingTasks = pendingImmediateTasks_[threadIndex];
+        if (!pendingTasks.empty())
+        {
+            enki::ICompletable observerTask;
+            for (InternalTaskInStack* task : pendingTasks)
+                task->observerDependency_.SetDependency(task, &observerTask);
+
+            for (InternalTaskInStack* task : pendingTasks)
+                taskScheduler_->AddTaskSetToPipe(task);
+            taskScheduler_->WaitforTask(&observerTask, priority);
+
+            for (InternalTaskInStack* task : pendingTasks)
+                task->observerDependency_.ClearDependency();
+            pendingTasks.clear();
+        }
+    }
+#endif
+    // Fallback queue never contains immediate tasks
+}
+
+void WorkQueue::CompleteImmediateForThisThread()
+{
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+    {
+        const unsigned threadIndex = GetThreadIndex();
+        CompleteImmediateForAnotherThread(threadIndex);
+        taskScheduler_->RunPinnedTasks();
+    }
+#endif
+}
+
+void WorkQueue::CompleteAll()
+{
+#ifdef URHO3D_THREADING
+    if (taskScheduler_)
+        taskScheduler_->WaitforAll();
+#endif
+
+    if (!fallbackTaskQueue_.empty())
+    {
+        for (auto& [taskPriority, task] : fallbackTaskQueue_)
+            task(0, this);
+        fallbackTaskQueue_.clear();
+    }
 }
 
 SharedPtr<WorkItem> WorkQueue::GetFreeItem()
 {
-    if (!poolItems_.empty())
-    {
-        SharedPtr<WorkItem> item = poolItems_.front();
-        poolItems_.pop_front();
-        return item;
-    }
-    else
-    {
-        // No usable items found, create a new one set it as pooled and return it.
-        SharedPtr<WorkItem> item(new WorkItem());
-        item->pooled_ = true;
-        return item;
-    }
+    // This function is deprecated, so we don't care about performance here.
+    return MakeShared<WorkItem>();
 }
 
 void WorkQueue::AddWorkItem(const SharedPtr<WorkItem>& item)
@@ -155,44 +533,7 @@ void WorkQueue::AddWorkItem(const SharedPtr<WorkItem>& item)
         return;
     }
 
-    // Check for duplicate items.
-    assert(ea::find(workItems_.begin(), workItems_.end(), item) == workItems_.end());
-
-    // Push to the main thread list to keep item alive
-    // Clear completed flag in case item is reused
-    workItems_.push_back(item);
-    item->completed_ = false;
-
-    // Make sure worker threads' list is safe to modify
-    if (threads_.size() && !paused_)
-        queueMutex_.Acquire();
-
-    // Find position for new item
-    if (queue_.empty())
-        queue_.push_back(item.Get());
-    else
-    {
-        bool inserted = false;
-
-        for (auto i = queue_.begin(); i != queue_.end(); ++i)
-        {
-            if ((*i)->priority_ <= item->priority_)
-            {
-                queue_.insert(i, item.Get());
-                inserted = true;
-                break;
-            }
-        }
-
-        if (!inserted)
-            queue_.push_back(item.Get());
-    }
-
-    if (threads_.size())
-    {
-        queueMutex_.Release();
-        paused_ = false;
-    }
+    PostTask([=] { item->workFunction_(item, GetThreadIndex()); }, ConvertLegacyPriority(item->priority_));
 }
 
 SharedPtr<WorkItem> WorkQueue::AddWorkItem(ea::function<void(unsigned threadIndex)> workFunction, unsigned priority)
@@ -205,288 +546,51 @@ SharedPtr<WorkItem> WorkQueue::AddWorkItem(ea::function<void(unsigned threadInde
     return item;
 }
 
-bool WorkQueue::RemoveWorkItem(SharedPtr<WorkItem> item)
+unsigned WorkQueue::GetNumIncomplete() const
 {
-    if (!item)
-        return false;
-
-    MutexLock lock(queueMutex_);
-
-    // Can only remove successfully if the item was not yet taken by threads for execution
-    auto i = ea::find(queue_.begin(), queue_.end(), item.Get());
-    if (i != queue_.end())
-    {
-        auto j = ea::find(workItems_.begin(), workItems_.end(), item);
-        if (j != workItems_.end())
-        {
-            queue_.erase(i);
-            ReturnToPool(item);
-            workItems_.erase(j);
-            return true;
-        }
-    }
-
-    return false;
+    unsigned result = fallbackTaskQueue_.size();
+#ifdef URHO3D_THREADING
+    result += globalTaskPool_.GetNumUsed();
+    result += globalPinnedTaskPool_.GetNumUsed();
+#endif
+    return result;
 }
 
-unsigned WorkQueue::RemoveWorkItems(const ea::vector<SharedPtr<WorkItem> >& items)
+bool WorkQueue::IsCompleted() const
 {
-    MutexLock lock(queueMutex_);
-    unsigned removed = 0;
-
-    for (auto i = items.begin(); i != items.end(); ++i)
-    {
-        auto j = ea::find(queue_.begin(), queue_.end(), i->Get());
-        if (j != queue_.end())
-        {
-            auto k = ea::find(workItems_.begin(), workItems_.end(), *i);
-            if (k != workItems_.end())
-            {
-                queue_.erase(j);
-                ReturnToPool(*k);
-                workItems_.erase(k);
-                ++removed;
-            }
-        }
-    }
-
-    return removed;
-}
-
-void WorkQueue::Pause()
-{
-    if (!paused_)
-    {
-        pausing_ = true;
-
-        queueMutex_.Acquire();
-        paused_ = true;
-
-        pausing_ = false;
-    }
-}
-
-void WorkQueue::Resume()
-{
-    if (paused_)
-    {
-        queueMutex_.Release();
-        paused_ = false;
-    }
-}
-
-
-void WorkQueue::Complete(unsigned priority)
-{
-    completing_ = true;
-
-    if (threads_.size())
-    {
-        Resume();
-
-        // Take work items also in the main thread until queue empty or no high-priority items anymore
-        while (!queue_.empty())
-        {
-            queueMutex_.Acquire();
-            if (!queue_.empty() && queue_.front()->priority_ >= priority)
-            {
-                WorkItem* item = queue_.front();
-                queue_.pop_front();
-                queueMutex_.Release();
-                item->workFunction_(item, 0);
-                item->completed_ = true;
-            }
-            else
-            {
-                queueMutex_.Release();
-                break;
-            }
-        }
-
-        // Wait for threaded work to complete
-        while (!IsCompleted(priority))
-        {
-        }
-
-        // If no work at all remaining, pause worker threads by leaving the mutex locked
-        if (queue_.empty())
-            Pause();
-    }
-    else
-    {
-        // No worker threads: ensure all high-priority items are completed in the main thread
-        while (!queue_.empty() && queue_.front()->priority_ >= priority)
-        {
-            WorkItem* item = queue_.front();
-            queue_.pop_front();
-            item->workFunction_(item, 0);
-            item->completed_ = true;
-        }
-    }
-
-    PurgeCompleted(priority);
-    completing_ = false;
-
-    ProcessMainThreadTasks();
-}
-
-unsigned WorkQueue::GetNumIncomplete(unsigned priority) const
-{
-    unsigned incomplete = 0;
-    for (const auto& workItem : workItems_)
-    {
-        if (workItem->priority_ >= priority && !workItem->completed_)
-            ++incomplete;
-    }
-
-    return incomplete;
-}
-
-bool WorkQueue::IsCompleted(unsigned priority) const
-{
-    for (const auto & workItem : workItems_)
-    {
-        if (workItem->priority_ >= priority && !workItem->completed_)
-            return false;
-    }
-
-    return true;
-}
-
-void WorkQueue::ProcessMainThreadTasks()
-{
-    for (const auto& callback : mainThreadTasks_)
-        callback(0);
-    mainThreadTasks_.Clear();
-}
-
-void WorkQueue::ProcessItems(unsigned threadIndex)
-{
-    bool wasActive = false;
-
-    for (;;)
-    {
-        if (shutDown_)
-            return;
-
-        if (pausing_ && !wasActive)
-            Time::Sleep(0);
-        else
-        {
-            queueMutex_.Acquire();
-            if (!queue_.empty())
-            {
-                wasActive = true;
-
-                WorkItem* item = queue_.front();
-                queue_.pop_front();
-                queueMutex_.Release();
-                item->workFunction_(item, threadIndex);
-                item->completed_ = true;
-            }
-            else
-            {
-                wasActive = false;
-
-                queueMutex_.Release();
-                Time::Sleep(0);
-            }
-        }
-    }
-}
-
-void WorkQueue::PurgeCompleted(unsigned priority)
-{
-    // Purge completed work items and send completion events. Do not signal items lower than priority threshold,
-    // as those may be user submitted and lead to eg. scene manipulation that could happen in the middle of the
-    // render update, which is not allowed
-    for (auto i = workItems_.begin(); i != workItems_.end();)
-    {
-        if ((*i)->completed_ && (*i)->priority_ >= priority)
-        {
-            if ((*i)->sendEvent_)
-            {
-                using namespace WorkItemCompleted;
-
-                VariantMap& eventData = GetEventDataMap();
-                eventData[P_ITEM] = i->Get();
-                SendEvent(E_WORKITEMCOMPLETED, eventData);
-            }
-
-            ReturnToPool(*i);
-            i = workItems_.erase(i);
-        }
-        else
-            ++i;
-    }
-}
-
-void WorkQueue::PurgePool()
-{
-    unsigned currentSize = poolItems_.size();
-    int difference = lastSize_ - currentSize;
-
-    // Difference tolerance, should be fairly significant to reduce the pool size.
-    for (unsigned i = 0; !poolItems_.empty() && difference > tolerance_ && i < (unsigned)difference; i++)
-        poolItems_.pop_front();
-
-    lastSize_ = currentSize;
-}
-
-void WorkQueue::ReturnToPool(SharedPtr<WorkItem>& item)
-{
-    // Check if this was a pooled item and set it to usable
-    if (item->pooled_)
-    {
-        // Reset the values to their defaults. This should
-        // be safe to do here as the completed event has
-        // already been handled and this is part of the
-        // internal pool.
-        item->start_ = nullptr;
-        item->end_ = nullptr;
-        item->aux_ = nullptr;
-        item->workFunction_ = nullptr;
-        item->priority_ = M_MAX_UNSIGNED;
-        item->sendEvent_ = false;
-        item->completed_ = false;
-
-        poolItems_.push_back(item);
-    }
-}
-
-void WorkQueue::HandleBeginFrame(StringHash eventType, VariantMap& eventData)
-{
-    ProcessMainThreadTasks();
-
-    // If no worker threads, complete low-priority work here
-    if (threads_.empty() && !queue_.empty())
-    {
-        URHO3D_PROFILE("CompleteWorkNonthreaded");
-
-        HiresTimer timer;
-
-        while (!queue_.empty() && timer.GetUSec(false) < maxNonThreadedWorkMs_ * 1000LL)
-        {
-            WorkItem* item = queue_.front();
-            queue_.pop_front();
-            item->workFunction_(item, 0);
-            item->completed_ = true;
-        }
-    }
-
-    // Complete and signal items down to the lowest priority
-    PurgeCompleted(0);
-    PurgePool();
+    return GetNumIncomplete() == 0;
 }
 
 unsigned WorkQueue::GetThreadIndex()
 {
-    return currentThreadIndex;
+#ifdef URHO3D_THREADING
+    if (workQueue && workQueue->taskScheduler_)
+        return workQueue->taskScheduler_->GetThreadNum();
+#endif
+    return Thread::IsMainThread() ? 0u : M_MAX_UNSIGNED;
 }
 
-unsigned WorkQueue::GetMaxThreadIndex()
+unsigned WorkQueue::GetThreadIndexCount()
 {
-    return maxThreadIndex;
+    return threadIndexCount;
+}
+
+bool WorkQueue::IsProcessingThread()
+{
+    return GetThreadIndex() < threadIndexCount;
+}
+
+void WorkQueue::CallFromMainThread(WorkFunction workFunction)
+{
+    PostTaskForMainThread([=] { workFunction(0u); }, TaskPriority::Immediate);
+}
+
+void WorkQueue::Complete(unsigned priority)
+{
+    if (priority == M_MAX_UNSIGNED)
+        CompleteImmediateForThisThread();
+    else
+        CompleteAll();
 }
 
 }

--- a/Source/Urho3D/Core/WorkQueue.h
+++ b/Source/Urho3D/Core/WorkQueue.h
@@ -22,24 +22,53 @@
 
 #pragma once
 
-#include "../Core/Mutex.h"
-#include "../Core/Object.h"
-#include "../Container/MultiVector.h"
+#include "Urho3D/Container/MultiVector.h"
+#include "Urho3D/Core/Mutex.h"
+#include "Urho3D/Core/Object.h"
 
+#include <EASTL/functional.h>
 #include <EASTL/list.h>
 #include <EASTL/span.h>
+#include <EASTL/unique_ptr.h>
+
 #include <atomic>
+
+#ifdef URHO3D_THREADING
+namespace enki
+{
+class ICompletable;
+class TaskScheduler;
+}
+#endif
 
 namespace Urho3D
 {
 
-/// Work item completed event.
-URHO3D_EVENT(E_WORKITEMCOMPLETED, WorkItemCompleted)
-{
-    URHO3D_PARAM(P_ITEM, Item);                        // WorkItem ptr
-}
+class WorkQueue;
 
-class WorkerThread;
+/// Priority of the task.
+enum class TaskPriority
+{
+    /// Special priority. Tasks of Immediate priority are executed and completed on CompleteImmediateForThisThread call.
+    /// @note If CompleteImmediateForThisThread is not called, "Immediate" tasks will be executed on Update.
+    /// @note Tasks of other priorities should not post tasks of Immediate priority.
+    Immediate,
+    /// Other priorities.
+    /// @{
+    Highest,
+    High,
+    Medium,
+    Low,
+    /// @}
+};
+
+/// Size of small task function that doesn't need to be allocated on the heap.
+static constexpr unsigned TaskBufferSize = sizeof(void*) * 8;
+
+/// Task function signature.
+/// Using internal EASTL function to get bigger storage.
+using TaskFunction = ea::internal::function_detail<TaskBufferSize, void(unsigned threadIndex, WorkQueue* queue)>;
+//using TaskFunction = ea::function<void(unsigned threadIndex, WorkQueue* queue)>;
 
 /// Vector-like collection that can be safely filled from different WorkQueue threads simultaneously.
 template <class T>
@@ -55,12 +84,10 @@ public:
     T& Emplace(Args&& ... args);
 };
 
-/// Task function signature.
-/// TODO: Get rid of parameter
+/// Deprecated.
 using WorkFunction = ea::function<void(unsigned threadIndex)>;
 
-/// Work queue item.
-/// @nobind
+/// Deprecated.
 struct WorkItem : public RefCounted
 {
     friend class WorkQueue;
@@ -76,18 +103,15 @@ public:
     void* aux_{};
     /// Priority. Higher value = will be completed first.
     unsigned priority_{};
-    /// Whether to send event on completion.
-    bool sendEvent_{};
-    /// Completed flag.
-    std::atomic<bool> completed_{};
 
 private:
-    bool pooled_{};
     /// Work function. Called without any parameters.
     WorkFunction workLambda_;
 };
 
 /// Work queue subsystem for multithreading.
+/// Tasks can be posted from any thread, but it is the most efficient from main thread or worker threads.
+/// Tasks posted from other threads may be posted with up to one frame delay and require heap allocation.
 class URHO3D_API WorkQueue : public Object
 {
     URHO3D_OBJECT(WorkQueue, Object);
@@ -101,95 +125,136 @@ public:
     ~WorkQueue() override;
 
     /// Create worker threads. Can only be called once.
-    void CreateThreads(unsigned numThreads);
+    void Initialize(unsigned numThreads);
+    /// Do work in main thread. Usually called once per frame.
+    void Update();
 
-    /// Invoke callback from main thread. May be called immediately.
-    void CallFromMainThread(WorkFunction workFunction);
+    /// Post the task for any processing thread.
+    void PostTask(TaskFunction&& task, TaskPriority priority = TaskPriority::Medium);
+    template <class T> void PostTask(T task, TaskPriority priority = TaskPriority::Medium);
+    /// Post the task for specified processing thread.
+    void PostTaskForThread(TaskFunction&& task, TaskPriority priority, unsigned threadIndex);
+    template <class T> void PostTaskForThread(T task, TaskPriority priority, unsigned threadIndex);
+    /// Post the task for main thread.
+    void PostTaskForMainThread(TaskFunction&& task, TaskPriority priority = TaskPriority::Medium);
+    template <class T> void PostTaskForMainThread(T task, TaskPriority priority = TaskPriority::Medium);
 
-    /// Get pointer to an usable WorkItem from the item pool. Allocate one if no more free items.
-    SharedPtr<WorkItem> GetFreeItem();
-    /// Add a work item and resume worker threads.
-    void AddWorkItem(const SharedPtr<WorkItem>& item);
-    /// Add a work item and resume worker threads.
-    SharedPtr<WorkItem> AddWorkItem(WorkFunction workFunction, unsigned priority = 0);
-    /// Remove a work item before it has started executing. Return true if successfully removed.
-    bool RemoveWorkItem(SharedPtr<WorkItem> item);
-    /// Remove a number of work items before they have started executing. Return the number of items successfully removed.
-    unsigned RemoveWorkItems(const ea::vector<SharedPtr<WorkItem> >& items);
-    /// Pause worker threads.
-    void Pause();
-    /// Resume worker threads.
-    void Resume();
-    /// Finish all queued work which has at least the specified priority. Main thread will also execute priority work. Pause worker threads if no more work remains.
-    void Complete(unsigned priority);
+    /// Complete tasks with Immediate priority, posted from this thread.
+    /// Can be called only from main thread or from another task.
+    void CompleteImmediateForThisThread();
+    /// Wait for completion of all tasks.
+    /// Should be called only from main thread.
+    void CompleteAll();
 
-    /// Set the pool telerance before it starts deleting pool items.
-    void SetTolerance(int tolerance) { tolerance_ = tolerance; }
+    /// Return number of incomplete tasks.
+    unsigned GetNumIncomplete() const;
+    /// Return whether all work is finished.
+    bool IsCompleted() const;
 
     /// Set how many milliseconds maximum per frame to spend on low-priority work, when there are no worker threads.
-    void SetNonThreadedWorkMs(int ms) { maxNonThreadedWorkMs_ = Max(ms, 1); }
-
-    /// Return number of worker threads.
-    unsigned GetNumThreads() const { return threads_.size(); }
-
-    /// Return number of incomplete tasks with at least the specified priority.
-    unsigned GetNumIncomplete(unsigned priority) const;
-    /// Return whether all work with at least the specified priority is finished.
-    bool IsCompleted(unsigned priority) const;
-    /// Return whether the queue is currently completing work in the main thread.
-    bool IsCompleting() const { return completing_; }
-
-    /// Return the pool tolerance.
-    int GetTolerance() const { return tolerance_; }
-
+    void SetNonThreadedWorkMs(int ms) { maxNonThreadedWorkMs_ = ea::max(ms, 1); }
     /// Return how many milliseconds maximum to spend on non-threaded low-priority work.
     int GetNonThreadedWorkMs() const { return maxNonThreadedWorkMs_; }
+
+    /// Return total number of threads processing tasks, including main thread.
+    unsigned GetNumProcessingThreads() const { return numProcessingThreads_; }
+    /// Return whether the queue is actually using multithreading.
+    bool IsMultithreaded() const { return numProcessingThreads_ > 1; }
 
     /// Return current thread index.
     static unsigned GetThreadIndex();
     /// Return number of threads used by WorkQueue, including main thread. Current thread index is always lower.
-    static unsigned GetMaxThreadIndex();
+    static unsigned GetThreadIndexCount();
+    /// Return whether current thread is one of processing threads.
+    static bool IsProcessingThread();
+
+    /// Deprecated API.
+    /// @{
+    void CallFromMainThread(WorkFunction workFunction);
+    void Complete(unsigned priority);
+
+    SharedPtr<WorkItem> GetFreeItem();
+    void AddWorkItem(const SharedPtr<WorkItem>& item);
+    SharedPtr<WorkItem> AddWorkItem(WorkFunction workFunction, unsigned priority = 0);
+    /// @}
 
 private:
-    /// Process main thread tasks.
+    void ProcessPostedTasks();
     void ProcessMainThreadTasks();
-    /// Process work items until shut down. Called by the worker threads.
-    void ProcessItems(unsigned threadIndex);
-    /// Purge completed work items which have at least the specified priority, and send completion events as necessary.
-    void PurgeCompleted(unsigned priority);
-    /// Purge the pool to reduce allocation where its unneeded.
-    void PurgePool();
-    /// Return a work item to the pool.
-    void ReturnToPool(SharedPtr<WorkItem>& item);
-    /// Handle frame start event. Purge completed work from the main thread queue, and perform work if no threads at all.
-    void HandleBeginFrame(StringHash eventType, VariantMap& eventData);
+    void PurgeProcessedTasksInFallbackQueue();
+    void CompleteImmediateForAnotherThread(unsigned threadIndex);
 
-    /// Worker threads.
-    ea::vector<SharedPtr<WorkerThread> > threads_;
+    template <class T> static TaskFunction WrapTask(T&& task);
+
+#ifdef URHO3D_THREADING
+    template <class T> void SetupInternalTask(T* internalTask, TaskFunction&& task, TaskPriority priority);
+
+    /// Thread-safe pool for infrequent low-priority tasks.
+    template <class T>
+    class TaskPool : public NonCopyable
+    {
+    public:
+        TaskPool();
+        ~TaskPool();
+        T* Allocate();
+        void Release(T* item);
+        unsigned GetNumUsed() const;
+
+    private:
+        ea::vector<ea::unique_ptr<T>> pool_;
+        ea::vector<T*> freeItems_;
+        mutable Mutex mutex_;
+    };
+
+    /// Thread-unsafe stack for frequent high-priority tasks.
+    template <class T>
+    class TaskStack : public MovableNonCopyable
+    {
+    public:
+        TaskStack();
+        ~TaskStack();
+        TaskStack(TaskStack&& other);
+        TaskStack& operator=(TaskStack&& other);
+
+        T* Allocate();
+        void Purge();
+
+    private:
+        ea::vector<ea::unique_ptr<T>> pool_;
+        unsigned nextFreeIndex_{};
+    };
+
+    class InternalTaskInPool;
+    class InternalPinnedTaskInPool;
+    class InternalTaskInStack;
+    class InternalPinnedTaskInStack;
+    class TaskCompletionObserver;
+
+    /// Task scheduler.
+    ea::unique_ptr<enki::TaskScheduler> taskScheduler_;
+
+    TaskPool<InternalTaskInPool> globalTaskPool_;
+    TaskPool<InternalPinnedTaskInPool> globalPinnedTaskPool_;
+    ea::vector<TaskStack<InternalTaskInStack>> localTaskStack_;
+    ea::vector<TaskStack<InternalPinnedTaskInStack>> localPinnedTaskStack_;
+
+    ea::vector<ea::vector<InternalTaskInStack*>> pendingImmediateTasks_;
+#endif
+
+    /// Task queue used for fallback if no threads available.
+    /// Used only for PostTask and PostTaskForThread, therefore no need for mutex.
+    ea::vector<ea::pair<TaskPriority, TaskFunction>> fallbackTaskQueue_;
+
+    /// Total number of threads, including main thread.
+    unsigned numProcessingThreads_{};
+
     /// Tasks to be invoked from main thread.
-    WorkQueueVector<WorkFunction> mainThreadTasks_;
-    /// Work item pool for reuse to cut down on allocation. The bool is a flag for item pooling and whether it is available or not.
-    ea::list<SharedPtr<WorkItem> > poolItems_;
-    /// Work item collection. Accessed only by the main thread.
-    ea::list<SharedPtr<WorkItem> > workItems_;
-    /// Work item prioritized queue for worker threads. Pointers are guaranteed to be valid (point to workItems).
-    ea::list<WorkItem*> queue_;
-    /// Worker queue mutex.
-    Mutex queueMutex_;
-    /// Shutting down flag.
-    std::atomic<bool> shutDown_;
-    /// Pausing flag. Indicates the worker threads should not contend for the queue mutex.
-    std::atomic<bool> pausing_;
-    /// Paused flag. Indicates the queue mutex being locked to prevent worker threads using up CPU time.
-    bool paused_;
-    /// Completing work in the main thread flag.
-    bool completing_;
-    /// Tolerance for the shared pool before it begins to deallocate.
-    int tolerance_;
-    /// Last size of the shared pool.
-    unsigned lastSize_;
+    ea::vector<TaskFunction> mainThreadTasks_;
+    ea::vector<TaskFunction> mainThreadTasksSwap_;
+    Mutex mainThreadTasksMutex_;
+
     /// Maximum milliseconds per frame to spend on low-priority work, when there are no worker threads.
-    int maxNonThreadedWorkMs_;
+    int maxNonThreadedWorkMs_{5};
 };
 
 /// Process arbitrary array in multiple threads. Callback is copied internally.
@@ -208,10 +273,10 @@ void ForEachParallel(WorkQueue* workQueue, unsigned bucket, unsigned size, Callb
     }
 
     std::atomic<unsigned> offset = 0;
-    const unsigned maxThreads = workQueue->GetNumThreads() + 1;
+    const unsigned maxThreads = workQueue->GetNumProcessingThreads();
     for (unsigned i = 0; i < maxThreads; ++i)
     {
-        workQueue->AddWorkItem([=, &offset](unsigned /*threadIndex*/) mutable
+        workQueue->PostTask([=, &offset]() mutable
         {
             while (true)
             {
@@ -222,9 +287,9 @@ void ForEachParallel(WorkQueue* workQueue, unsigned bucket, unsigned size, Callb
                 const unsigned endIndex = ea::min(beginIndex + bucket, size);
                 callback(beginIndex, endIndex);
             }
-        }, M_MAX_UNSIGNED);
+        }, TaskPriority::Immediate);
     }
-    workQueue->Complete(M_MAX_UNSIGNED);
+    workQueue->CompleteImmediateForThisThread();
 }
 
 /// Process collection in multiple threads.
@@ -255,7 +320,7 @@ void ForEachParallel(WorkQueue* workQueue, Collection&& collection, const Callba
 template <class T>
 void WorkQueueVector<T>::Clear()
 {
-    MultiVector<T>::Clear(WorkQueue::GetMaxThreadIndex());
+    MultiVector<T>::Clear(WorkQueue::GetThreadIndexCount());
 }
 
 template <class T>
@@ -273,5 +338,58 @@ T& WorkQueueVector<T>::Emplace(Args&& ... args)
     return this->EmplaceBack(threadIndex, std::forward<Args>(args)...);
 }
 /// @}
+
+/// WorkQueue implementation
+/// @{
+template <class T> TaskFunction WorkQueue::WrapTask(T&& task)
+{
+    static constexpr bool hasIndexQueue = ea::is_invocable_r_v<void, T, unsigned, WorkQueue*>;
+    static constexpr bool hasIndex = ea::is_invocable_r_v<void, T, unsigned>;
+    static constexpr bool hasQueue = ea::is_invocable_r_v<void, T, WorkQueue*>;
+    static constexpr bool hasNone = ea::is_invocable_r_v<void, T>;
+    static_assert(hasIndexQueue || hasIndex || hasQueue || hasNone, "Invalid task signature");
+
+    if constexpr (hasIndexQueue)
+        return TaskFunction{ea::move(task)};
+    else if constexpr (hasIndex)
+        return [task = ea::move(task)](unsigned threadIndex, WorkQueue*) mutable { task(threadIndex); };
+    else if constexpr (hasQueue)
+        return [task = ea::move(task)](unsigned, WorkQueue* workQueue) mutable { task(workQueue); };
+    else
+        return [task = ea::move(task)](unsigned, WorkQueue*) mutable { task(); };
+}
+
+template <class T> void WorkQueue::PostTask(T task, TaskPriority priority)
+{
+    if (!IsProcessingThread())
+    {
+        auto wrappedTask = [task = ea::move(task), priority](WorkQueue* workQueue) mutable
+        { workQueue->PostTask(ea::move(task), priority); };
+
+        PostTaskForMainThread(ea::move(wrappedTask), priority);
+        return;
+    }
+
+    PostTask(WrapTask(ea::move(task)), priority);
+}
+
+template <class T> void WorkQueue::PostTaskForThread(T task, TaskPriority priority, unsigned threadIndex)
+{
+    if (!IsProcessingThread())
+    {
+        auto wrappedTask = [task = ea::move(task), priority, threadIndex](WorkQueue* workQueue) mutable
+        { workQueue->PostTaskForThread(ea::move(task), priority, threadIndex); };
+
+        PostTaskForMainThread(ea::move(wrappedTask), priority);
+        return;
+    }
+
+    PostTaskForThread(WrapTask(ea::move(task)), priority, threadIndex);
+}
+
+template <class T> void WorkQueue::PostTaskForMainThread(T task, TaskPriority priority)
+{
+    PostTaskForMainThread(WrapTask(ea::move(task)), priority);
+}
 
 }

--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -299,14 +299,11 @@ bool Engine::Initialize(const StringVariantMap& parameters)
     // Set amount of worker threads according to the available physical CPU cores. Using also hyperthreaded cores results in
     // unpredictable extra synchronization overhead. Also reserve one core for the main thread
 #ifdef URHO3D_THREADING
-    unsigned numThreads = GetParameter(EP_WORKER_THREADS).GetBool() ? GetNumPhysicalCPUs() - 1 : 0;
-    if (numThreads)
-    {
-        GetSubsystem<WorkQueue>()->CreateThreads(numThreads);
-
-        URHO3D_LOGINFOF("Created %u worker thread%s", numThreads, numThreads > 1 ? "s" : "");
-    }
+    const unsigned numThreads = GetParameter(EP_WORKER_THREADS).GetBool() ? GetNumPhysicalCPUs() - 1 : 0;
+#else
+    const unsigned numThreads = 0;
 #endif
+    GetSubsystem<WorkQueue>()->Initialize(numThreads);
 
     auto* cache = GetSubsystem<ResourceCache>();
 

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -472,10 +472,10 @@ void Drawable::RemoveFromOctree()
 void Drawable::RequestUpdateBatchesDelayed(const FrameInfo& frame)
 {
     auto workQueue = context_->GetSubsystem<WorkQueue>();
-    workQueue->CallFromMainThread([this, &frame](unsigned)
+    workQueue->PostTaskForMainThread([this, &frame]()
     {
         UpdateBatchesDelayed(frame);
-    });
+    }, TaskPriority::Immediate);
 }
 
 bool WriteDrawablesToOBJ(const ea::vector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV)

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -202,7 +202,6 @@ class URHO3D_API Drawable : public Component, public PipelineStateTracker
 
     friend class Octant;
     friend class Octree;
-    friend void UpdateDrawablesWork(const WorkItem* item, unsigned threadIndex);
 
 public:
     /// Construct.

--- a/Source/Urho3D/Graphics/Octree.cpp
+++ b/Source/Urho3D/Graphics/Octree.cpp
@@ -50,22 +50,6 @@ namespace Urho3D
 static const float DEFAULT_OCTREE_SIZE = 1000.0f;
 static const int DEFAULT_OCTREE_LEVELS = 8;
 
-void UpdateDrawablesWork(const WorkItem* item, unsigned threadIndex)
-{
-    URHO3D_PROFILE("UpdateDrawablesWork");
-    const FrameInfo& frame = *(reinterpret_cast<FrameInfo*>(item->aux_));
-    auto** start = reinterpret_cast<Drawable**>(item->start_);
-    auto** end = reinterpret_cast<Drawable**>(item->end_);
-
-    while (start != end)
-    {
-        Drawable* drawable = *start;
-        if (drawable)
-            drawable->Update(frame);
-        ++start;
-    }
-}
-
 inline bool CompareRayQueryResults(const RayQueryResult& lhs, const RayQueryResult& rhs)
 {
     return lhs.distance_ < rhs.distance_;
@@ -490,30 +474,12 @@ void Octree::Update(const FrameInfo& frame)
 
         pendingNodeTransforms_.Clear();
 
-        int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
-        int drawablesPerItem = Max((int)(drawableUpdates_.size() / numWorkItems), 1);
-
-        auto start = drawableUpdates_.begin();
-        // Create a work item for each thread
-        for (int i = 0; i < numWorkItems; ++i)
+        ForEachParallel(queue, drawableUpdates_, [this, &frame](unsigned, Drawable* drawable)
         {
-            SharedPtr<WorkItem> item = queue->GetFreeItem();
-            item->priority_ = M_MAX_UNSIGNED;
-            item->workFunction_ = UpdateDrawablesWork;
-            item->aux_ = const_cast<FrameInfo*>(&frame);
+            if (drawable)
+                drawable->Update(frame);
+        });
 
-            auto end = drawableUpdates_.end();
-            if (i < numWorkItems - 1 && end - start > drawablesPerItem)
-                end = start + drawablesPerItem;
-
-            item->start_ = &(*start);
-            item->end_ = &(*end);
-            queue->AddWorkItem(item);
-
-            start = end;
-        }
-
-        queue->Complete(M_MAX_UNSIGNED);
         scene->EndThreadedUpdate();
     }
 

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -317,7 +317,7 @@ View::View(Context* context) :
     renderer_(GetSubsystem<Renderer>())
 {
     // Create octree query and scene results vector for each thread
-    unsigned numThreads = GetSubsystem<WorkQueue>()->GetNumThreads() + 1; // Worker threads + main thread
+    unsigned numThreads = GetSubsystem<WorkQueue>()->GetNumProcessingThreads();
     tempDrawables_.resize(numThreads);
     sceneResults_.resize(numThreads);
 }
@@ -924,7 +924,7 @@ void View::GetDrawables()
             result.maxZ_ = 0.0f;
         }
 
-        int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
+        int numWorkItems = queue->GetNumProcessingThreads();
         int drawablesPerItem = tempDrawables.size() / numWorkItems;
 
         auto start = tempDrawables.begin();
@@ -1379,7 +1379,7 @@ void View::UpdateGeometries()
                 }
             }
 
-            int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
+            int numWorkItems = queue->GetNumProcessingThreads();
             int drawablesPerItem = threadedGeometries_.size() / numWorkItems;
 
             auto start = threadedGeometries_.begin();

--- a/Source/Urho3D/RenderPipeline/BatchCompositor.cpp
+++ b/Source/Urho3D/RenderPipeline/BatchCompositor.cpp
@@ -241,13 +241,13 @@ void BatchCompositor::ComposeShadowBatches()
         const unsigned numSplits = lightProcessor->GetNumSplits();
         for (unsigned splitIndex = 0; splitIndex < numSplits; ++splitIndex)
         {
-            workQueue_->AddWorkItem([=](unsigned threadIndex)
+            workQueue_->PostTask([=](unsigned threadIndex)
             {
                 BeginShadowBatchesComposition(lightIndex, lightProcessor->GetMutableSplit(splitIndex));
-            }, M_MAX_UNSIGNED);
+            }, TaskPriority::Immediate);
         }
     }
-    workQueue_->Complete(M_MAX_UNSIGNED);
+    workQueue_->CompleteImmediateForThisThread();
 
     // Finalize shadow batches
     FinalizeShadowBatchesComposition();
@@ -404,13 +404,13 @@ void BatchCompositor::FinalizeShadowBatchesComposition()
         const unsigned numSplits = lightProcessor->GetNumSplits();
         for (unsigned splitIndex = 0; splitIndex < numSplits; ++splitIndex)
         {
-            workQueue_->AddWorkItem([=](unsigned threadIndex)
+            workQueue_->PostTask([=](unsigned threadIndex)
             {
                 lightProcessor->GetMutableSplit(splitIndex)->FinalizeShadowBatches();
-            }, M_MAX_UNSIGNED);
+            }, TaskPriority::Immediate);
         }
     }
-    workQueue_->Complete(M_MAX_UNSIGNED);
+    workQueue_->CompleteImmediateForThisThread();
 }
 
 }

--- a/Source/Urho3D/RenderPipeline/DrawableProcessor.cpp
+++ b/Source/Urho3D/RenderPipeline/DrawableProcessor.cpp
@@ -201,7 +201,7 @@ void DrawableProcessor::OnUpdateBegin(const FrameInfo& frameInfo)
 
     // Clean temporary containers
     sceneZRangeTemp_.clear();
-    sceneZRangeTemp_.resize(WorkQueue::GetMaxThreadIndex());
+    sceneZRangeTemp_.resize(WorkQueue::GetThreadIndexCount());
     sceneZRange_ = {};
 
     isDrawableUpdated_.resize(numDrawables_);

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -797,7 +797,7 @@ void Scene::Update(float timeStep)
 void Scene::BeginThreadedUpdate()
 {
     // Check the work queue subsystem whether it actually has created worker threads. If not, do not enter threaded mode.
-    if (GetSubsystem<WorkQueue>()->GetNumThreads())
+    if (GetSubsystem<WorkQueue>()->IsMultithreaded())
         threadedUpdate_ = true;
 }
 

--- a/Source/Urho3D/Urho2D/Renderer2D.h
+++ b/Source/Urho3D/Urho2D/Renderer2D.h
@@ -71,8 +71,6 @@ class URHO3D_API Renderer2D : public Drawable
 {
     URHO3D_OBJECT(Renderer2D, Drawable);
 
-    friend void CheckDrawableVisibilityWork(const WorkItem* item, unsigned threadIndex);
-
 public:
     /// Construct.
     explicit Renderer2D(Context* context);


### PR DESCRIPTION
Changes:

- Most of existing code should still work (with deprecated WorkQueue API)
- `TaskPriority` enum is added with 5 priorities.
  - Highest/High/Medium/Low priorities are just priorities, nothing special.
  - Immediate priority tasks **must** be waited for, and they will run first of course.
  - Therefore, the most common exiting use case is supported:

```
for (...)
    queue->AddWorkItem(task, M_MAX_UNSIGNED);
queue->Complete(M_MAX_UNSIGNED);
```
or 
```
for (...)
    queue->PostTask(task, TaskPriority::Immediate);
queue->CompleteImmediateForThisThread();
```

- You can wait for completion for *all* tasks.
- You *cannot* wait for completion for all tasks of specified priority anymore.
  - API for task dependencies and waiting for specified task is planned at some point.
- You can post the task to the main thread from any thread at any moment.
  - It is the most efficient if you are doing that from task threads.
  - It will be completed during next `queue->Complete*` call or between frames
- Task function is just `void()` now, you can use `GetThreadIndex` to get current thread index between 0 and `GetThreadIndexCount`

Why?

- Writing efficient and safe task scheduler is not easy, let's not reinvent the wheel.
- I really want the flexibility to "just post" the tasks whenever I need it, to the pool or to the main thread.
- enkiTS is used in game engine and it's only 1 cpp file without any exposure in our headers, so no compile time impact