### PR TITLE
Fix frame limiter

### DIFF
--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -772,7 +772,7 @@ void Engine::ApplyFrameLimit()
 #else
     // If on iOS/tvOS and target framerate is 60 or above, just let the animation callback handle frame timing
     // instead of waiting ourselves
-    if (maxFps < 60)
+    if (maxFps && maxFps < 60)
 #endif
     {
         URHO3D_PROFILE("ApplyFrameLimit");


### PR DESCRIPTION
Game will still try to divide time per maxFps so maxFps should never be 0. By fact, it caused a crash on iOS.