### PR TITLE
Added colorwrite property to Pass

### DIFF
--- a/Source/Urho3D/Graphics/Technique.cpp
+++ b/Source/Urho3D/Graphics/Technique.cpp
@@ -45,6 +45,7 @@ Pass::Pass(const ea::string& name) :
     lightingMode_(LIGHTING_UNLIT),
     shadersLoadedFrameNumber_(0),
     alphaToCoverage_(false),
+    colorWrite_(true),
     depthWrite_(true),
     isDesktop_(false)
 {
@@ -82,6 +83,12 @@ void Pass::SetDepthTestMode(CompareMode mode)
 void Pass::SetLightingMode(PassLightingMode mode)
 {
     lightingMode_ = mode;
+}
+
+void Pass::SetColorWrite(bool enable)
+{
+    colorWrite_ = enable;
+    MarkPipelineStateHashDirty();
 }
 
 void Pass::SetDepthWrite(bool enable)
@@ -209,6 +216,7 @@ unsigned Pass::RecalculatePipelineStateHash() const
     CombineHash(hash, blendMode_);
     CombineHash(hash, cullMode_);
     CombineHash(hash, depthTestMode_);
+    CombineHash(hash, colorWrite_);
     CombineHash(hash, depthWrite_);
     CombineHash(hash, alphaToCoverage_);
     CombineHash(hash, MakeHash(vertexShaderName_));
@@ -341,6 +349,9 @@ bool Technique::BeginLoad(Deserializer& source)
                     newPass->SetDepthTestMode((CompareMode)GetStringListIndex(depthTest.c_str(), compareModeNames, CMP_LESS));
             }
 
+            if (passElem.HasAttribute("colorwrite"))
+                newPass->SetColorWrite(passElem.GetBool("colorwrite"));
+
             if (passElem.HasAttribute("depthwrite"))
                 newPass->SetDepthWrite(passElem.GetBool("depthwrite"));
 
@@ -389,6 +400,7 @@ SharedPtr<Technique> Technique::Clone(const ea::string& cloneName) const
         newPass->SetBlendMode(srcPass->GetBlendMode());
         newPass->SetDepthTestMode(srcPass->GetDepthTestMode());
         newPass->SetLightingMode(srcPass->GetLightingMode());
+        newPass->SetColorWrite(srcPass->GetColorWrite());
         newPass->SetDepthWrite(srcPass->GetDepthWrite());
         newPass->SetAlphaToCoverage(srcPass->GetAlphaToCoverage());
         newPass->SetIsDesktop(srcPass->IsDesktop());

--- a/Source/Urho3D/Graphics/Technique.h
+++ b/Source/Urho3D/Graphics/Technique.h
@@ -101,6 +101,9 @@ public:
     /// Set depth write on/off.
     /// @property
     void SetDepthWrite(bool enable);
+    /// Set color write on/off.
+    /// @property
+    void SetColorWrite(bool enable);
     /// Set alpha-to-coverage on/off.
     /// @property
     void SetAlphaToCoverage(bool enable);
@@ -154,6 +157,10 @@ public:
 
     /// Return last shaders loaded frame number.
     unsigned GetShadersLoadedFrameNumber() const { return shadersLoadedFrameNumber_; }
+
+    /// Return color write mode.
+    /// @property
+    bool GetColorWrite() const { return colorWrite_; }
 
     /// Return depth write mode.
     /// @property
@@ -225,6 +232,8 @@ private:
     PassLightingMode lightingMode_;
     /// Last shaders loaded frame number.
     unsigned shadersLoadedFrameNumber_;
+    /// Color write mode.
+    bool colorWrite_;
     /// Depth write mode.
     bool depthWrite_;
     /// Alpha-to-coverage mode.

--- a/Source/Urho3D/RenderPipeline/PipelineStateBuilder.cpp
+++ b/Source/Urho3D/RenderPipeline/PipelineStateBuilder.cpp
@@ -217,10 +217,10 @@ void PipelineStateBuilder::SetupLightVolumePassState(const LightProcessor* light
 void PipelineStateBuilder::SetupUserPassState(const Drawable* drawable,
     const Material* material, const Pass* pass, bool lightMaskToStencil)
 {
+    pipelineStateDesc_.colorWriteEnabled_ = pass->GetColorWrite();
     pipelineStateDesc_.depthWriteEnabled_ = pass->GetDepthWrite();
     pipelineStateDesc_.depthCompareFunction_ = pass->GetDepthTestMode();
 
-    pipelineStateDesc_.colorWriteEnabled_ = true;
     pipelineStateDesc_.blendMode_ = pass->GetBlendMode();
     pipelineStateDesc_.alphaToCoverageEnabled_ = pass->GetAlphaToCoverage() || material->GetAlphaToCoverage();
     pipelineStateDesc_.constantDepthBias_ = material->GetDepthBias().constantBias_;


### PR DESCRIPTION
Ability to disable colorwrite is necessary for making small depth pre-passes on clusters of geometry