### PR TITLE
Add resources to mac os bundle correctly

### DIFF
--- a/Source/Samples/CMakeLists.txt
+++ b/Source/Samples/CMakeLists.txt
@@ -85,24 +85,28 @@ if (XCODE)
         # Default app icon on the iOS/tvOS home screen
         list(APPEND RESOURCE_FILES ${rbfx_SOURCE_DIR}/bin/Data/Textures/UrhoIcon.png)
     endif ()
+    
+    # Add REOSOURCE FILES to the bundle
     set_source_files_properties (${RESOURCE_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     target_sources(Samples PRIVATE ${RESOURCE_FILES})
+    
+    # Add other resources to the bundle
+    if (URHO3D_PACKAGING)
+        set_source_files_properties (${URHO3D_DATA_PAKS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+        target_sources(Samples PRIVATE ${URHO3D_DATA_PAKS})
+    else ()
+        set_source_files_properties (
+            "${rbfx_SOURCE_DIR}/bin/Data" "${rbfx_SOURCE_DIR}/bin/CoreData"
+            PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+        target_sources(Samples PRIVATE
+            "${rbfx_SOURCE_DIR}/bin/Data" "${rbfx_SOURCE_DIR}/bin/CoreData")
+    endif ()
 
     if (IOS)
         set_target_properties(Samples
             PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME \${PRODUCT_NAME}
                        MACOSX_BUNDLE_GUI_IDENTIFIER com.github.rbfx.\${PRODUCT_NAME:rfc1034identifier:lower}
         )
-        if (URHO3D_PACKAGING)
-            set_source_files_properties (${URHO3D_DATA_PAKS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-            target_sources(Samples PRIVATE ${URHO3D_DATA_PAKS})
-        else ()
-            set_source_files_properties (
-                "${rbfx_SOURCE_DIR}/bin/Data" "${rbfx_SOURCE_DIR}/bin/CoreData"
-                PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-            target_sources(Samples PRIVATE
-                "${rbfx_SOURCE_DIR}/bin/Data" "${rbfx_SOURCE_DIR}/bin/CoreData")
-        endif ()
     endif ()
 endif ()
 

--- a/Source/Samples/SamplesManager.cpp
+++ b/Source/Samples/SamplesManager.cpp
@@ -178,8 +178,15 @@ void SamplesManager::Setup()
 #if MOBILE
     engineParameters_[EP_ORIENTATIONS] = "Portrait";
 #endif
-    if (!engineParameters_.contains(EP_RESOURCE_PREFIX_PATHS))
+    if (!engineParameters_.contains(EP_RESOURCE_PREFIX_PATHS)) 
+    {
         engineParameters_[EP_RESOURCE_PREFIX_PATHS] = ";..;../..";
+        if (GetPlatform() == PlatformId::MacOS ||
+            GetPlatform() == PlatformId::iOS)
+            engineParameters_[EP_RESOURCE_PREFIX_PATHS] = ";../Resources;../..";
+        else
+            engineParameters_[EP_RESOURCE_PREFIX_PATHS] = ";..;../..";
+    }
     engineParameters_[EP_AUTOLOAD_PATHS] = "Autoload";
 #if DESKTOP
     GetCommandLineParser().add_option("--sample", commandLineArgsTemp_);


### PR DESCRIPTION
XCode will put resources with this specific property into a bundle's subfolder Resources in the bundle. The fix is
1. Adding a property Resources to Data and CoreData folders so they would appear in the resulting bundle
2. Fix paths set into the engine as they must contain the Resources subfolder.

In my past experience, changing engine resource paths did not affect the application functionality.

According to Gleb, such change requires a deep review.