### PR TITLE
Fixed bug in SystemUI::AddFont() / SystemUI::ReallocateFontTexture()

### DIFF
--- a/Source/Urho3D/SystemUI/SystemUI.cpp
+++ b/Source/Urho3D/SystemUI/SystemUI.cpp
@@ -384,11 +384,12 @@ void SystemUI::ReallocateFontTexture()
     ImGuiIO& io = ui::GetIO();
     ImGuiPlatformIO& platform_io = ui::GetPlatformIO();
 
+    // Initialize per-screen font atlases.
+    ClearPerScreenFonts();
+
     // Store main atlas, imgui expects it.
     io.Fonts->TexID = AllocateFontTexture(io.Fonts);
 
-    // Initialize per-screen font atlases.
-    ClearPerScreenFonts();
     io.AllFonts.push_back(io.Fonts);
     for (ImGuiPlatformMonitor& monitor : platform_io.Monitors)
     {


### PR DESCRIPTION
SystemUI::AddFont() isn't working properly, as in SystemUI::ReallocateFontTexture() first the atlas for new font is allocated, and then the texture which holds the glyphs is immediately destroyed. It seems that the correct order or calls should be:

- Invalidate the cache via ClearPerScreenFonts()
- Create the atlas for new font