### PR TITLE
Prefab instancing flags

### DIFF
--- a/Source/Urho3D/Scene/PrefabReference.cpp
+++ b/Source/Urho3D/Scene/PrefabReference.cpp
@@ -230,15 +230,50 @@ void PrefabReference::RemoveInstance()
     instanceNode_ = nullptr;
 }
 
-void PrefabReference::InstantiatePrefab(const NodePrefab& nodePrefab)
+void PrefabReference::InstantiatePrefab(const NodePrefab& nodePrefab, PrefabInstanceFlags instanceFlags)
 {
     const auto flags = PrefabLoadFlag::KeepExistingComponents | PrefabLoadFlag::KeepExistingChildren
         | PrefabLoadFlag::LoadAsTemporary | PrefabLoadFlag::IgnoreRootAttributes;
     PrefabReaderFromMemory reader{nodePrefab};
     node_->Load(reader, flags);
+    if (instanceFlags != PrefabInstanceFlag::None) {
+        for (const AttributePrefab& attribute : nodePrefab.GetNode().GetAttributes()) {
+            auto name = attribute.GetName().c_str();
+            if (instanceFlags & PrefabInstanceFlag::SetNodeScale) {
+                if (attribute.GetName() == "Scale") {
+                    node_->SetAttribute("Scale", attribute.GetValue());
+                }
+            }
+            if (instanceFlags & PrefabInstanceFlag::SetNodePosition) {
+                if (attribute.GetName() == "Position") {
+                    node_->SetAttribute("Position", attribute.GetValue());
+                }
+            }
+            if (instanceFlags & PrefabInstanceFlag::SetNodeRotation) {
+                if (attribute.GetName() == "Rotation") {
+                    node_->SetAttribute("Rotation", attribute.GetValue());
+                }
+            }
+            if (instanceFlags & PrefabInstanceFlag::SetNodeTags) {
+                if (attribute.GetName() == "Tags") {
+                    node_->SetAttribute("Tags", attribute.GetValue());
+                }
+            }
+            if (instanceFlags & PrefabInstanceFlag::SetNodeName) {
+                if (attribute.GetName() == "Name") {
+                    node_->SetAttribute("Name", attribute.GetValue());
+                }
+            }
+            if (instanceFlags & PrefabInstanceFlag::SetNodeVariables) {
+                if (attribute.GetName() == "Variables") {
+                    node_->SetAttribute("Variables", attribute.GetValue());
+                }
+            }
+        }
+    }
 }
 
-void PrefabReference::CreateInstance(bool tryInplace)
+void PrefabReference::CreateInstance(bool tryInplace, PrefabInstanceFlags instanceFlags)
 {
     // Remove existing instance if moved to another node
     if (instanceNode_ && instanceNode_ != node_)
@@ -259,10 +294,10 @@ void PrefabReference::CreateInstance(bool tryInplace)
 
     RemoveTemporaryComponents(node_);
     RemoveTemporaryChildren(node_);
-    InstantiatePrefab(nodePrefab);
+    InstantiatePrefab(nodePrefab, instanceFlags);
 }
 
-void PrefabReference::SetPrefab(PrefabResource* prefab, ea::string_view path, bool createInstance)
+void PrefabReference::SetPrefab(PrefabResource* prefab, ea::string_view path, bool createInstance, PrefabInstanceFlags instanceFlags)
 {
     if (prefab == prefab_ && path == path_)
     {
@@ -288,7 +323,7 @@ void PrefabReference::SetPrefab(PrefabResource* prefab, ea::string_view path, bo
     }
 
     if (createInstance)
-        CreateInstance();
+        CreateInstance(false, instanceFlags);
 }
 
 void PrefabReference::SetPrefabAttr(ResourceRef prefab)

--- a/Source/Urho3D/Scene/PrefabReference.cpp
+++ b/Source/Urho3D/Scene/PrefabReference.cpp
@@ -236,39 +236,27 @@ void PrefabReference::InstantiatePrefab(const NodePrefab& nodePrefab, PrefabInst
         | PrefabLoadFlag::LoadAsTemporary | PrefabLoadFlag::IgnoreRootAttributes;
     PrefabReaderFromMemory reader{nodePrefab};
     node_->Load(reader, flags);
-    if (instanceFlags != PrefabInstanceFlag::None) {
-        for (const AttributePrefab& attribute : nodePrefab.GetNode().GetAttributes()) {
-            auto name = attribute.GetName().c_str();
-            if (instanceFlags & PrefabInstanceFlag::SetNodeScale) {
-                if (attribute.GetName() == "Scale") {
-                    node_->SetAttribute("Scale", attribute.GetValue());
-                }
-            }
-            if (instanceFlags & PrefabInstanceFlag::SetNodePosition) {
-                if (attribute.GetName() == "Position") {
-                    node_->SetAttribute("Position", attribute.GetValue());
-                }
-            }
-            if (instanceFlags & PrefabInstanceFlag::SetNodeRotation) {
-                if (attribute.GetName() == "Rotation") {
-                    node_->SetAttribute("Rotation", attribute.GetValue());
-                }
-            }
-            if (instanceFlags & PrefabInstanceFlag::SetNodeTags) {
-                if (attribute.GetName() == "Tags") {
-                    node_->SetAttribute("Tags", attribute.GetValue());
-                }
-            }
-            if (instanceFlags & PrefabInstanceFlag::SetNodeName) {
-                if (attribute.GetName() == "Name") {
-                    node_->SetAttribute("Name", attribute.GetValue());
-                }
-            }
-            if (instanceFlags & PrefabInstanceFlag::SetNodeVariables) {
-                if (attribute.GetName() == "Variables") {
-                    node_->SetAttribute("Variables", attribute.GetValue());
-                }
-            }
+
+    if (instanceFlags != PrefabInstanceFlag::None)
+    {
+        static const ea::unordered_map<ea::string, PrefabInstanceFlag> attributeToFlag = {
+            {"Scale", PrefabInstanceFlag::UpdateScale},
+            {"Position", PrefabInstanceFlag::UpdatePosition},
+            {"Rotation", PrefabInstanceFlag::UpdateRotation},
+            {"Tags", PrefabInstanceFlag::UpdateTags},
+            {"Name", PrefabInstanceFlag::UpdateName},
+            {"Variables", PrefabInstanceFlag::UpdateVariables},
+        };
+
+        for (const AttributePrefab& attribute : nodePrefab.GetNode().GetAttributes())
+        {
+            const auto iter = attributeToFlag.find(attribute.GetName());
+            if (iter == attributeToFlag.end())
+                continue;
+
+            const auto& [name, flag] = *iter;
+            if (instanceFlags.Test(flag))
+                node_->SetAttribute(name, attribute.GetValue());
         }
     }
 }

--- a/Source/Urho3D/Scene/PrefabReference.h
+++ b/Source/Urho3D/Scene/PrefabReference.h
@@ -37,6 +37,20 @@ enum class PrefabInlineFlag
 };
 URHO3D_FLAGSET(PrefabInlineFlag, PrefabInlineFlags);
 
+/// Controls, which attributes of top-level node of the prefab are copied to the scene node, assoociated with prefab instance
+/// By default, no copying is made.
+enum class PrefabInstanceFlag
+{
+    None = 0,
+    SetNodeScale = 1 << 0,
+    SetNodePosition = 1 << 1,
+    SetNodeRotation = 1 << 2,
+    SetNodeTags = 1 << 3,
+    SetNodeName = 1 << 4,
+    SetNodeVariables = 1 << 5,
+};
+URHO3D_FLAGSET(PrefabInstanceFlag, PrefabInstanceFlags);
+
 /// Component that instantiates prefab resource into the parent Node.
 class URHO3D_API PrefabReference : public Component
 {
@@ -53,7 +67,8 @@ public:
 
     /// Attributes.
     /// @{
-    void SetPrefab(PrefabResource* prefab, ea::string_view path = {}, bool createInstance = true);
+    void SetPrefab(PrefabResource* prefab, ea::string_view path = {}, bool createInstance = true,
+                   PrefabInstanceFlags instanceFlags = PrefabInstanceFlag::None);
     PrefabResource* GetPrefab() const { return prefab_; }
     void SetPath(ea::string_view path);
     const ea::string& GetPath() const { return path_; }
@@ -86,7 +101,7 @@ private:
 
     void RemoveTemporaryComponents(Node* node) const;
     void RemoveTemporaryChildren(Node* node) const;
-    void InstantiatePrefab(const NodePrefab& nodePrefab);
+    void InstantiatePrefab(const NodePrefab& nodePrefab, PrefabInstanceFlags instanceFlags);
 
     void MarkPrefabDirty() { prefabDirty_ = true; }
 
@@ -99,7 +114,7 @@ private:
     void RemoveInstance();
     /// Create prefab instance. Spawns all nodes and components in the prefab.
     /// Removes all existing children and components except this PrefabReference.
-    void CreateInstance(bool tryInplace = false);
+    void CreateInstance(bool tryInplace = false, PrefabInstanceFlags instanceFlags = PrefabInstanceFlag::None);
 
     SharedPtr<PrefabResource> prefab_;
     ResourceRef prefabRef_;

--- a/Source/Urho3D/Scene/PrefabReference.h
+++ b/Source/Urho3D/Scene/PrefabReference.h
@@ -39,7 +39,7 @@ URHO3D_FLAGSET(PrefabInlineFlag, PrefabInlineFlags);
 
 /// Controls which attributes of the top-level node of the prefab are copied to the scene node
 /// containing PrefabReference. By default, none are copied.
-enum class PrefabInstanceFlag : unsigned
+enum class PrefabInstanceFlag
 {
     None = 0,
     UpdateName = 1 << 0,
@@ -49,7 +49,7 @@ enum class PrefabInstanceFlag : unsigned
     UpdateScale = 1 << 4,
     UpdateVariables = 1 << 5,
 
-    UpdateAll = 0xffffffff
+    UpdateAll = 0x7fffffff
 };
 URHO3D_FLAGSET(PrefabInstanceFlag, PrefabInstanceFlags);
 

--- a/Source/Urho3D/Scene/PrefabReference.h
+++ b/Source/Urho3D/Scene/PrefabReference.h
@@ -37,17 +37,19 @@ enum class PrefabInlineFlag
 };
 URHO3D_FLAGSET(PrefabInlineFlag, PrefabInlineFlags);
 
-/// Controls, which attributes of top-level node of the prefab are copied to the scene node, assoociated with prefab instance
-/// By default, no copying is made.
-enum class PrefabInstanceFlag
+/// Controls which attributes of the top-level node of the prefab are copied to the scene node
+/// containing PrefabReference. By default, none are copied.
+enum class PrefabInstanceFlag : unsigned
 {
     None = 0,
-    SetNodeScale = 1 << 0,
-    SetNodePosition = 1 << 1,
-    SetNodeRotation = 1 << 2,
-    SetNodeTags = 1 << 3,
-    SetNodeName = 1 << 4,
-    SetNodeVariables = 1 << 5,
+    UpdateName = 1 << 0,
+    UpdateTags = 1 << 1,
+    UpdatePosition = 1 << 2,
+    UpdateRotation = 1 << 3,
+    UpdateScale = 1 << 4,
+    UpdateVariables = 1 << 5,
+
+    UpdateAll = 0xffffffff
 };
 URHO3D_FLAGSET(PrefabInstanceFlag, PrefabInstanceFlags);
 
@@ -68,7 +70,7 @@ public:
     /// Attributes.
     /// @{
     void SetPrefab(PrefabResource* prefab, ea::string_view path = {}, bool createInstance = true,
-                   PrefabInstanceFlags instanceFlags = PrefabInstanceFlag::None);
+        PrefabInstanceFlags instanceFlags = PrefabInstanceFlag::None);
     PrefabResource* GetPrefab() const { return prefab_; }
     void SetPath(ea::string_view path);
     const ea::string& GetPath() const { return path_; }


### PR DESCRIPTION
Introduced new parameter to PrefabReference::SetPrefab(): instanceFlags, which allows the instantiated prefab to appear in game the same as it appears in Editor. instanceFlags controls, which attributes of the root prefab node is copied to the scene node, associated with prefab instance.