### PR TITLE
Allows to have hardware skinned models with bone count > 128

### DIFF
--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -1160,12 +1160,13 @@ void AnimatedModel::UpdateSoftwareSkinningState()
     if (renderer->GetSkinningMode() == SKINNING_AUTO && model_)
     {
         // Fallback to software skinning if too many bones affect the model
-        if (geometrySkinMatrices_.empty() && model_->GetSkeleton().GetNumBones() > Graphics::GetMaxBones()){
-            URHO3D_LOGWARNING("Model {} have {} bones, but only {} can be skinned on GPU. Falling "
-                             "back to software skinning.",
-                             model_->GetName(),
-                             model_->GetSkeleton().GetNumBones(),
-                             Graphics::GetMaxBones());
+        if (geometrySkinMatrices_.empty() && model_->GetSkeleton().GetNumBones() > Graphics::GetMaxBones())
+        {
+            URHO3D_LOGWARNING(
+                "Model {} have {} bones, but only {} can be skinned on GPU. "
+                "Falling back to software skinning.",
+                model_->GetName(), model_->GetSkeleton().GetNumBones(), Graphics::GetMaxBones());
+
             softwareSkinning_ = true;
         }
     }

--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -1160,8 +1160,14 @@ void AnimatedModel::UpdateSoftwareSkinningState()
     if (renderer->GetSkinningMode() == SKINNING_AUTO && model_)
     {
         // Fallback to software skinning if too many bones affect the model
-        if (geometrySkinMatrices_.empty() && model_->GetSkeleton().GetNumBones() > Graphics::GetMaxBones())
+        if (geometrySkinMatrices_.empty() && model_->GetSkeleton().GetNumBones() > Graphics::GetMaxBones()){
+            URHO3D_LOGWARNING("Model {} have {} bones, but only {} can be skinned on GPU. Falling "
+                             "back to software skinning.",
+                             model_->GetName(),
+                             model_->GetSkeleton().GetNumBones(),
+                             Graphics::GetMaxBones());
             softwareSkinning_ = true;
+        }
     }
 }
 

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
@@ -1938,6 +1938,10 @@ unsigned Graphics::GetFormat(const ea::string& formatName)
 
 unsigned Graphics::GetMaxBones()
 {
+    /// User-specified number of bones
+    if (maxBonesHWSkinned)
+        return maxBonesHWSkinned;
+
     return 128;
 }
 

--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -106,6 +106,7 @@ WindowMode ToWindowMode(bool fullscreen, bool borderless)
 }
 
 GraphicsCaps Graphics::caps;
+unsigned Graphics::maxBonesHWSkinned = 0;
 
 void Graphics::SetExternalWindow(void* window)
 {

--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -644,6 +644,11 @@ void Graphics::OnScreenModeChanged()
     SendEvent(E_SCREENMODE, eventData);
 }
 
+void Graphics::SetMaxBones(unsigned numBones)
+{
+    maxBonesHWSkinned = numBones;
+}
+
 void RegisterGraphicsLibrary(Context* context)
 {
     Animation::RegisterObject(context);

--- a/Source/Urho3D/Graphics/Graphics.h
+++ b/Source/Urho3D/Graphics/Graphics.h
@@ -750,8 +750,8 @@ public:
     /// Return the API-specific texture format from a textual description, for example "rgb".
     static unsigned GetFormat(const ea::string& formatName);
 
-    /// Sets the maximum number of supported bones for hardware skinning. Check GPU capabilities before setting..
-    static void SetMaxBones(unsigned);
+    /// Sets the maximum number of supported bones for hardware skinning. Check GPU capabilities before setting.
+    static void SetMaxBones(unsigned maxBones);
     /// Return maximum number of supported bones for skinning.
     static unsigned GetMaxBones();
     /// Return whether is using an OpenGL 3 context. Return always false on DirectX 11.

--- a/Source/Urho3D/Graphics/Graphics.h
+++ b/Source/Urho3D/Graphics/Graphics.h
@@ -750,6 +750,8 @@ public:
     /// Return the API-specific texture format from a textual description, for example "rgb".
     static unsigned GetFormat(const ea::string& formatName);
 
+    /// Sets the maximum number of supported bones for hardware skinning. Check GPU capabilities before setting..
+    static void SetMaxBones(unsigned);
     /// Return maximum number of supported bones for skinning.
     static unsigned GetMaxBones();
     /// Return whether is using an OpenGL 3 context. Return always false on DirectX 11.
@@ -993,6 +995,8 @@ private:
     static bool gl3Support;
     /// Graphics capabilities. Static for easier access.
     static GraphicsCaps caps;
+    /// Max number of bones which can be skinned on GPU. Zero means default value.
+    static unsigned maxBonesHWSkinned;
 };
 
 /// Register Graphics library objects.

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -2160,12 +2160,21 @@ unsigned Graphics::GetFormat(CompressedFormat format) const
     }
 }
 
+void Graphics::SetMaxBones(unsigned numBones)
+{
+    maxBonesHWSkinned = numBones;
+}
+
 unsigned Graphics::GetMaxBones()
 {
 #ifdef RPI
     // At the moment all RPI GPUs are low powered and only have limited number of uniforms
     return 32;
 #else
+    /// User-specified number of bones
+    if (maxBonesHWSkinned)
+        return maxBonesHWSkinned;
+    /// The defaults
     return gl3Support ? 128 : 64;
 #endif
 }

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -2160,20 +2160,16 @@ unsigned Graphics::GetFormat(CompressedFormat format) const
     }
 }
 
-void Graphics::SetMaxBones(unsigned numBones)
-{
-    maxBonesHWSkinned = numBones;
-}
-
 unsigned Graphics::GetMaxBones()
 {
+    /// User-specified number of bones
+    if (maxBonesHWSkinned)
+        return maxBonesHWSkinned;
+
 #ifdef RPI
     // At the moment all RPI GPUs are low powered and only have limited number of uniforms
     return 32;
 #else
-    /// User-specified number of bones
-    if (maxBonesHWSkinned)
-        return maxBonesHWSkinned;
     /// The defaults
     return gl3Support ? 128 : 64;
 #endif


### PR DESCRIPTION
* Added Grphics::SetMaxBones(unsigned) which sets the max limit of HW skinned bones. Do not use values greater than 330, it may cause issues later.
* Addad a warning when model is skinned on CPU due to bone count being too high