### PR TITLE
Solves the issue #566

### DIFF
--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -1000,7 +1000,10 @@ void UI::Render(VertexBuffer* buffer, const ea::vector<UIBatch>& batches, unsign
             drawQueue->CommitShaderParameterGroup(SP_CAMERA);
         }
 
-        if (drawQueue->BeginShaderParameterGroup(SP_MATERIAL))
+        // Assuming that custom batch material have different parameters that
+        // the material in previous batch. Further optimizations are possible.
+        // Solves the issue #566
+        if (drawQueue->BeginShaderParameterGroup(SP_MATERIAL, batch.customMaterial_))
         {
             if (!batch.customMaterial_)
                 drawQueue->AddShaderParameter(PSP_MATDIFFCOLOR, Color(1.0f, 1.0f, 1.0f, 1.0f));

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -967,6 +967,7 @@ void UI::Render(VertexBuffer* buffer, const ea::vector<UIBatch>& batches, unsign
 
     const float elapsedTime = GetSubsystem<Time>()->GetElapsedTime();
     UIBatchStateCreateContext batchStateCreateContext{ vertexBuffer_, nullptr };
+    Material* lastCustomMaterial = nullptr;
     for (unsigned i = batchStart; i < batchEnd; ++i)
     {
         const UIBatch& batch = batches[i];
@@ -1002,8 +1003,7 @@ void UI::Render(VertexBuffer* buffer, const ea::vector<UIBatch>& batches, unsign
 
         // Assuming that custom batch material have different parameters that
         // the material in previous batch. Further optimizations are possible.
-        // Solves the issue #566
-        if (drawQueue->BeginShaderParameterGroup(SP_MATERIAL, batch.customMaterial_))
+        if (drawQueue->BeginShaderParameterGroup(SP_MATERIAL, lastCustomMaterial != batch.customMaterial_))
         {
             if (!batch.customMaterial_)
                 drawQueue->AddShaderParameter(PSP_MATDIFFCOLOR, Color(1.0f, 1.0f, 1.0f, 1.0f));
@@ -1045,6 +1045,8 @@ void UI::Render(VertexBuffer* buffer, const ea::vector<UIBatch>& batches, unsign
         drawQueue->CommitShaderResources();
 
         drawQueue->Draw(batch.vertexStart_ / UI_VERTEX_SIZE, (batch.vertexEnd_ - batch.vertexStart_) / UI_VERTEX_SIZE);
+
+        lastCustomMaterial = batch.customMaterial_;
     }
 
     drawQueue->Execute();

--- a/Source/Urho3D/UI/UIBatch.cpp
+++ b/Source/Urho3D/UI/UIBatch.cpp
@@ -406,7 +406,8 @@ bool UIBatch::Merge(const UIBatch& batch)
         batch.scissor_ != scissor_ ||
         batch.texture_ != texture_ ||
         batch.vertexData_ != vertexData_ ||
-        batch.vertexStart_ != vertexEnd_)
+        batch.vertexStart_ != vertexEnd_ ||
+        batch.customMaterial_ != customMaterial_)
         return false;
 
     vertexEnd_ = batch.vertexEnd_;


### PR DESCRIPTION
In issue #566 all consecutive custom materials in UI was treated as one. That's no longer the case.

Probably some more optimizations can be added, if two different UI materials have exactly the same parameters