### PR TITLE
Fix compilation error when building without URHO3D_SHADER_OPTIMIZER

### DIFF
--- a/Source/Urho3D/Shader/ShaderOptimizer.cpp
+++ b/Source/Urho3D/Shader/ShaderOptimizer.cpp
@@ -27,6 +27,8 @@
 
 #ifdef URHO3D_SHADER_OPTIMIZER
     #include <spirv-tools/optimizer.hpp>
+#else
+#include <Urho3D/Core/Assert.h>
 #endif
 
 namespace Urho3D


### PR DESCRIPTION
self-explanatory