### PR TITLE
Fix typo in Ptr.h

### DIFF
--- a/Source/Urho3D/Container/Ptr.h
+++ b/Source/Urho3D/Container/Ptr.h
@@ -193,7 +193,7 @@ public:
     {
         if (this->GetRefCounted() != rhs.GetRefCounted())
         {
-            ThisType temp{std::move(rhs)};
+            ThisType temp{ea::move(rhs)};
             this->Swap(temp);
         }
         return *this;


### PR DESCRIPTION
Changes an std::move to ea::move.