### PR TITLE
Navigatable keyboard and joystick input improvements

### DIFF
--- a/Source/ThirdParty/RmlUi/Include/RmlUi/Core/Elements/ElementFormControlInput.h
+++ b/Source/ThirdParty/RmlUi/Include/RmlUi/Core/Elements/ElementFormControlInput.h
@@ -52,6 +52,10 @@ public:
 	ElementFormControlInput(const String& tag);
 	virtual ~ElementFormControlInput();
 
+	/// Returns the control's type name.
+	/// @return The type name.
+	const String& GetTypeName() const { return type_name; }
+
 	/// Returns a string representation of the current value of the form control.
 	/// @return The value of the form control.
 	String GetValue() const override;

--- a/Source/Urho3D/RmlUI/RmlNavigable.cpp
+++ b/Source/Urho3D/RmlUI/RmlNavigable.cpp
@@ -259,6 +259,8 @@ void RmlNavigable::SetNavigated(bool navigated, NavigableEventMode eventMode)
 {
     if (navigated)
     {
+        this->Focus();
+
         auto element = TagMatchRecursive(matching_tags, this);
         targetElement_ = (element) ? element->GetObserverPtr() : nullptr;
     }

--- a/Source/Urho3D/RmlUI/RmlNavigable.cpp
+++ b/Source/Urho3D/RmlUI/RmlNavigable.cpp
@@ -289,7 +289,7 @@ void RmlNavigable::SetPressed(bool pressed, NavigableInputSource inputSource, Na
         {
             bool isFocused = target == this->GetOwnerDocument()->GetFocusLeafNode();
 
-            if (!isFocused)
+            if (!isFocused || !RmlNavigationManager::DoesElementHandleDirectionKeys(target))
             {
                 target->Focus();
                 target->Click();

--- a/Source/Urho3D/RmlUI/RmlNavigable.h
+++ b/Source/Urho3D/RmlUI/RmlNavigable.h
@@ -90,6 +90,7 @@ public:
     Rml::Element* AsElement() { return this; }
     const Rml::Element* AsElement() const { return this; }
     RmlUIComponent* GetOwner() const { return owner_; }
+    Rml::Element* GetTargetElement() const { return targetElement_.get(); }
     /// @}
 
     /// Return properties of the navigable.
@@ -139,6 +140,8 @@ private:
 
     template <class T> void ForEach(Rml::Element* element, const T& func);
     template <class T> void ForEachChild(Rml::Element* element, const T& func);
+
+    Rml::ObserverPtr<Rml::Element> targetElement_;
 
     const Rml::String group_;
     WeakPtr<RmlUIComponent> owner_;

--- a/Source/Urho3D/RmlUI/RmlNavigable.h
+++ b/Source/Urho3D/RmlUI/RmlNavigable.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../Core/Object.h"
+#include "Core/EventListener.h"
 
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/ElementInstancer.h>
@@ -61,6 +62,16 @@ enum class NavigablePressMode
     Toggle,
     /// Navigable is pressed when mouse button or key pressed, and depressed only when another element is pressed.
     StickyToggle,
+};
+
+class RmlNavigableEventListener : public Rml::EventListener
+{
+public:
+    ~RmlNavigableEventListener() override;
+    /// Process the incoming Event
+    virtual void ProcessEvent(Rml::Event& event);
+
+    bool enabled_{true};
 };
 
 /// UI element that can be navigated with arrows.
@@ -151,6 +162,9 @@ private:
 
     Vector2 position_;
     bool disabled_{};
+
+    Rml::UniquePtr<RmlNavigableEventListener> clickBlocker_;
+
     struct Cache
     {
         bool hovered_{};

--- a/Source/Urho3D/RmlUI/RmlNavigationManager.cpp
+++ b/Source/Urho3D/RmlUI/RmlNavigationManager.cpp
@@ -87,23 +87,39 @@ RmlNavigationManager::~RmlNavigationManager()
 {
 }
 
-void RmlNavigationManager::HandleDirectionKeyEvent(StringHash eventType, VariantMap& eventData)
+bool RmlNavigationManager::DoesElementHandleDirectionKeys(Rml::Element* element)
 {
-    // Let control in focus handle directional input.
-    auto elementInFocus = owner_->GetDocument()->GetFocusLeafNode();
-    if (auto formControl = dynamic_cast<Rml::ElementFormControl*>(elementInFocus))
+    if (!element)
     {
-        if (auto inputControl = dynamic_cast<Rml::ElementFormControlInput*>(elementInFocus))
+        return false;
+    }
+
+    if (auto formControl = dynamic_cast<Rml::ElementFormControl*>(element))
+    {
+        if (const auto inputControl = dynamic_cast<Rml::ElementFormControlInput*>(element))
         {
             auto& typeName = inputControl->GetTypeName();
             if (typeName == "range" || typeName == "text" || typeName == "password")
-                return;
+                return true;
         }
-        else if (dynamic_cast<Rml::ElementFormControlSelect*>(elementInFocus))
+        else if (dynamic_cast<Rml::ElementFormControlSelect*>(element))
         {
-            return;
+            return true;
         }
-        else if (dynamic_cast<Rml::ElementFormControlTextArea*>(elementInFocus))
+        else if (dynamic_cast<Rml::ElementFormControlTextArea*>(element))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void RmlNavigationManager::HandleDirectionKeyEvent(StringHash eventType, VariantMap& eventData)
+{
+    // Let control in focus handle directional input.
+    if (auto doc = owner_->GetDocument())
+    {
+        if (DoesElementHandleDirectionKeys(doc->GetFocusLeafNode()))
         {
             return;
         }

--- a/Source/Urho3D/RmlUI/RmlNavigationManager.cpp
+++ b/Source/Urho3D/RmlUI/RmlNavigationManager.cpp
@@ -29,6 +29,9 @@
 #include "../RmlUI/RmlUIComponent.h"
 
 #include <RmlUi/Core/ElementDocument.h>
+#include <Core/Elements/ElementFormControlInput.h>
+#include <Core/Elements/ElementFormControlSelect.h>
+#include <Core/Elements/ElementFormControlTextArea.h>
 
 #include "../DebugNew.h"
 
@@ -86,6 +89,26 @@ RmlNavigationManager::~RmlNavigationManager()
 
 void RmlNavigationManager::HandleDirectionKeyEvent(StringHash eventType, VariantMap& eventData)
 {
+    // Let control in focus handle directional input.
+    auto elementInFocus = owner_->GetDocument()->GetFocusLeafNode();
+    if (auto formControl = dynamic_cast<Rml::ElementFormControl*>(elementInFocus))
+    {
+        if (auto inputControl = dynamic_cast<Rml::ElementFormControlInput*>(elementInFocus))
+        {
+            auto& typeName = inputControl->GetTypeName();
+            if (typeName == "range" || typeName == "text" || typeName == "password")
+                return;
+        }
+        else if (dynamic_cast<Rml::ElementFormControlSelect*>(elementInFocus))
+        {
+            return;
+        }
+        else if (dynamic_cast<Rml::ElementFormControlTextArea*>(elementInFocus))
+        {
+            return;
+        }
+    }
+
     const bool pressed = eventType == E_KEYDOWN;
     const auto key = static_cast<Key>(eventData[KeyDown::P_KEY].GetUInt());
     const Vector2 direction = KeyToDirection(key);

--- a/Source/Urho3D/RmlUI/RmlNavigationManager.h
+++ b/Source/Urho3D/RmlUI/RmlNavigationManager.h
@@ -70,6 +70,7 @@ public:
     /// @{
     void AddNavigable(RmlNavigable* navigable);
     void RemoveNavigable(RmlNavigable* navigable);
+    static bool DoesElementHandleDirectionKeys(Rml::Element* element);
     /// @}
 
 private:

--- a/Source/Urho3D/RmlUI/RmlUI.cpp
+++ b/Source/Urho3D/RmlUI/RmlUI.cpp
@@ -262,6 +262,7 @@ static const ea::unordered_map<unsigned, uint16_t> keyMap{
 RmlUI::RmlUI(Context* context, const char* name)
     : Object(context)
     , name_(name)
+    , directionInput_(MakeShared<DirectionalPadAdapter>(context_))
 {
     // Initializing first instance of RmlUI, initialize backend library as well.
     if (rmlInstanceCounter.fetch_add(1) == 0)
@@ -284,6 +285,13 @@ RmlUI::RmlUI(Context* context, const char* name)
 
     Input* input = context_->GetSubsystem<Input>();
     URHO3D_ASSERT(input);
+
+    // Only handle joystick input as the keyboard is handled directly.
+    directionInput_->SetSubscriptionMask(DirectionalPadAdapterMask::Joystick);
+    SubscribeToEvent(directionInput_, E_KEYUP, &RmlUI::HandleKeyDown);
+    SubscribeToEvent(directionInput_, E_KEYDOWN, &RmlUI::HandleKeyUp);
+    directionInput_->SetEnabled(true);
+
     SubscribeToEvent(input, E_MOUSEBUTTONDOWN, &RmlUI::HandleMouseButtonDown);
     SubscribeToEvent(input, E_MOUSEBUTTONUP, &RmlUI::HandleMouseButtonUp);
     SubscribeToEvent(input, E_MOUSEMOVE, &RmlUI::HandleMouseMove);

--- a/Source/Urho3D/RmlUI/RmlUI.h
+++ b/Source/Urho3D/RmlUI/RmlUI.h
@@ -24,16 +24,15 @@
 
 #pragma once
 
-
-#include "../Core/Object.h"
-#include "../Core/Signal.h"
-#include "../Graphics/Texture2D.h"
-#include "../Math/Vector2.h"
+#include "Urho3D/Core/Object.h"
+#include "Urho3D/Core/Signal.h"
+#include "Urho3D/Graphics/Texture2D.h"
+#include "Urho3D/Input/DirectionalPadAdapter.h"
+#include "Urho3D/Math/Vector2.h"
 
 #include <EASTL/vector.h>
 #include <EASTL/string.h>
 #include <RmlUi/Core/ElementDocument.h>
-#include <RmlUi/Core/EventListener.h>
 #include <RmlUi/Core/Context.h>
 
 
@@ -162,6 +161,9 @@ private:
     bool isRendering_ = true;
     /// Other instances of RmlUI.
     ea::vector<WeakPtr<RmlUI>> siblingSubsystems_;
+
+    /// Joystick adapter for directional input.
+    SharedPtr<DirectionalPadAdapter> directionInput_;
 
     friend class Detail::RmlPlugin;
 };


### PR DESCRIPTION
RmlUI now supports gamepad input globally, i.e. user can change range or drop down selection from gamepad.
Navigatable ignores directional input if it is handled by control widget
Checkboxes, sliders and dropdowns are available from gamepad.