### PR TITLE
WIP: fix: error C2027: use of undefined type 'Urho3D::Scene'

### DIFF
--- a/Source/Urho3D/UI/SplashScreen.h
+++ b/Source/Urho3D/UI/SplashScreen.h
@@ -26,6 +26,7 @@
 #include "../Audio/SoundSource.h"
 #include "../Audio/Sound.h"
 #include "../UI/Sprite.h"
+#include "../Scene/Scene.h"
 
 namespace Urho3D
 {

--- a/Source/Urho3D/UI/TextRenderer3D.h
+++ b/Source/Urho3D/UI/TextRenderer3D.h
@@ -26,6 +26,7 @@
 
 #include "../Scene/LogicComponent.h"
 #include "../UI/Text3D.h"
+#include "../UI/Font.h"
 
 #include <EASTL/unordered_map.h>
 


### PR DESCRIPTION
If you import SplashScreen header without Scene header, an error of C2027 will occurs at build time.
This fix will solve this problem by adding Scene header into SplashScreen header.

See the error in picture above:
![splashscreen_error](https://github.com/rbfx/rbfx/assets/10354401/9b3d821c-9ae0-476f-ad4d-035f88b776c6)

There are other headers that have the same problem:
- UI/TextRenderer3D.h
