### PR TITLE
Fix for deferred lighting GLSL compilation failure due to vec3/vec4 

### DIFF
--- a/bin/CoreData/Shaders/GLSL/v2/DeferredLight.glsl
+++ b/bin/CoreData/Shaders/GLSL/v2/DeferredLight.glsl
@@ -44,7 +44,7 @@ void main()
 
     vec4 worldPos = GetDeferredWorldPos(vScreenPos, depth);
     half3 eyeVec = normalize(-worldPos.xyz);
-    worldPos.xyz += STEREO_VAR(cCameraPos);
+    worldPos.xyz += STEREO_VAR(cCameraPos).xyz;
 
     half3 normal = DecodeNormal(normalInput);
     #ifdef URHO3D_PHYSICAL_MATERIAL


### PR DESCRIPTION
Fix for deferred lighting GLSL compilation failure due to vec3/vec4 assignment mismatch