### PR TITLE
Support for Vive Trackers

### DIFF
--- a/Source/Samples/120_HelloVR/HelloVR.cpp
+++ b/Source/Samples/120_HelloVR/HelloVR.cpp
@@ -122,6 +122,16 @@ void HelloVR::CreateScene()
     // Create kinematic bodies for hands
     SetupHandComponents(rig->GetLeftHandPose(), rig->GetLeftHandAim());
     SetupHandComponents(rig->GetRightHandPose(), rig->GetRightHandAim());
+
+    auto leftFoot = rigNode->CreateChild("left_foot");
+    auto foot_model = leftFoot->CreateComponent<StaticModel>();
+    foot_model->SetModel(cache->GetResource<Model>("Models/Box.mdl"));
+    foot_model->SetMaterial(cache->GetResource<Material>("Materials/Constant/MattTransparent.xml"));
+
+    auto rightFoot = rigNode->CreateChild("right_foot");
+    foot_model = rightFoot->CreateComponent<StaticModel>();
+    foot_model->SetModel(cache->GetResource<Model>("Models/Box.mdl"));
+    foot_model->SetMaterial(cache->GetResource<Material>("Materials/Constant/MattTransparent.xml"));
 }
 
 void HelloVR::CreateInstructions()
@@ -268,6 +278,36 @@ void HelloVR::Update()
                 GrabDynamicObject(rigDesc.leftHandPose_, VRHand::Left);
             else
                 ReleaseDynamicObject(rigDesc.leftHandPose_);
+        }
+    }
+
+    if (XRBinding* leftFoot = virtualReality->GetInputBinding("left_foot"))
+    {
+        if (auto foot = rigNode->GetChild("left_foot"))
+        {
+            if (leftFoot->IsBound())
+            {
+                foot->SetEnabled(true);
+                foot->SetTransformMatrix(leftFoot->GetTransformMatrix());
+                foot->SetScale(0.2f); // so we're not comically large boxes
+            }
+            else
+                foot->SetEnabled(false);
+        }
+    }
+
+    if (XRBinding* leftFoot = virtualReality->GetInputBinding("right_foot"))
+    {
+        if (auto foot = rigNode->GetChild("right_foot"))
+        {
+            if (leftFoot->IsBound())
+            {
+                foot->SetEnabled(true);
+                foot->SetTransformMatrix(leftFoot->GetTransformMatrix());
+                foot->SetScale(0.2f); // so we're not comically large boxes
+            }
+            else
+                foot->SetEnabled(false);
         }
     }
 

--- a/Source/Samples/120_HelloVR/HelloVR.cpp
+++ b/Source/Samples/120_HelloVR/HelloVR.cpp
@@ -296,14 +296,14 @@ void HelloVR::Update()
         }
     }
 
-    if (XRBinding* leftFoot = virtualReality->GetInputBinding("right_foot"))
+    if (XRBinding* rightFoot = virtualReality->GetInputBinding("right_foot"))
     {
         if (auto foot = rigNode->GetChild("right_foot"))
         {
-            if (leftFoot->IsBound())
+            if (rightFoot->IsBound())
             {
                 foot->SetEnabled(true);
-                foot->SetTransformMatrix(leftFoot->GetTransformMatrix());
+                foot->SetTransformMatrix(rightFoot->GetTransformMatrix());
                 foot->SetScale(0.2f); // so we're not comically large boxes
             }
             else

--- a/Source/Urho3D/XR/OpenXR.cpp
+++ b/Source/Urho3D/XR/OpenXR.cpp
@@ -862,10 +862,19 @@ ea::pair<SharedPtr<OpenXRBinding>, SharedPtr<OpenXRBinding>> CreateBinding(
 
     // Create action
     XrActionCreateInfo createInfo = {XR_TYPE_ACTION_CREATE_INFO};
+    XrPath customPath;
+
     if (handed)
     {
         createInfo.countSubactionPaths = 2;
         createInfo.subactionPaths = handPaths.data();
+    }
+    else if (element.HasAttribute("subaction"))
+    {
+        // User specified subaction path (originally for vive trackers), currently preferring fully specified paths in the manifest,
+        // but a case where that isn't workable isn't unlikely to pop in the future, so support it ahead of time.
+        xrStringToPath(instance, element.GetAttributeCString("subaction"), &customPath);
+        createInfo.subactionPaths = &customPath;
     }
 
     const ea::string localizedName = localization->Get(name);
@@ -1405,6 +1414,10 @@ void OpenXR::InitializeActiveExtensions(RenderBackend backend)
     ActivateOptionalExtension( //
         activeExtensions_, supportedExtensions_, XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME);
 
+    // Trackers
+    ActivateOptionalExtension(
+        activeExtensions_, supportedExtensions_, XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
+
     for (const ea::string& extension : userExtensions_)
         ActivateOptionalExtension(activeExtensions_, supportedExtensions_, extension.c_str());
 }
@@ -1425,6 +1438,14 @@ bool OpenXR::InitializeTweaks(RenderBackend backend)
         return true;
     }
 #endif
+
+    // SteamVR currently is reporting depth modes (D32_FLOAT) that it doesn't actually support as frame depth attachments
+    // Expect to see something like "SteamVR / OpenXR : holographic" in system name
+    // TODO: in the future when it's somewhat known what sort of other strange oddities like this exist
+    //       coalesce them into something like a json overrides rules file like the graphics tweaks stuff.
+    if (systemName_.contains("steamvr", false))
+        features_.depthLayer_ = false;
+
     return true;
 }
 

--- a/Source/Urho3D/XR/VirtualReality.h
+++ b/Source/Urho3D/XR/VirtualReality.h
@@ -102,6 +102,7 @@ public:
     Vector3 GetPosition() const { return storedData_.GetMatrix3x4().Translation(); }
     Quaternion GetRotation() const { return storedData_.GetMatrix3x4().Rotation(); }
     const Matrix3x4& GetTransformMatrix() const { return storedData_.GetMatrix3x4(); }
+    VariantType GetExpectedType() const { return dataType_; }
     /// @}
 
     /// Returns stored variant value.

--- a/bin/CoreData/XR/DefaultManifest.xml
+++ b/bin/CoreData/XR/DefaultManifest.xml
@@ -45,6 +45,11 @@
             -->
 
             <action name="vibrate" type="haptic" handed="true"/>
+            
+            <!-- Most common Vive Tracker arrangement -->
+            <action name="left_foot" type="pose" />
+            <action name="right_foot" type="pose" />
+            <action name="waist" type="pose" />
         </actions>
 
         <!-- Porifles are xrSuggestInteractionProfileBindings -->
@@ -168,10 +173,10 @@
 
             <bind action="menu" path="/user/hand/left/input/menu/click" />
 
-            <bind action="a" path="/user/hand/right/a/click" />
-            <bind action="b" path="/user/hand/right/b/click" />
-            <bind action="x" path="/user/hand/left/x/click" />
-            <bind action="y" path="/user/hand/left/y/click" />
+            <bind action="a" path="/user/hand/right/input/a/click" />
+            <bind action="b" path="/user/hand/right/input/b/click" />
+            <bind action="x" path="/user/hand/left/input/x/click" />
+            <bind action="y" path="/user/hand/left/input/y/click" />
 
             <bind action="shoulder" path="/user/hand/left/input/shoulder/click" />
             <bind action="shoulder" path="/user/hand/right/input/shoulder/click" />
@@ -205,10 +210,13 @@
             <bind action="stickdown" path="/user/hand/left/input/thumbstick/click" />
             <bind action="stickdown" path="/user/hand/right/input/thumbstick/click" />
 
-            <bind action="a" path="/user/hand/right/a/click" />
-            <bind action="b" path="/user/hand/right/b/click" />
-            <bind action="x" path="/user/hand/left/x/click" />
-            <bind action="y" path="/user/hand/left/y/click" />
+            <bind action="a" path="/user/hand/right/input/a/click" />
+            <bind action="b" path="/user/hand/right/input/b/click" />
+            <bind action="x" path="/user/hand/left/input/x/click" />
+            <bind action="y" path="/user/hand/left/input/y/click" />
+            
+            <bind action="vibrate" path="/user/hand/left/output/haptic" />
+            <bind action="vibrate" path="/user/hand/right/output/haptic" />
         </profile>
 
         <!-- Valve Index, treating left-hand A/B as Oculus X/Y -->
@@ -275,6 +283,13 @@
 
             <bind action="vibrate" path="/user/hand/left/output/haptic" />
             <bind action="vibrate" path="/user/hand/right/output/haptic" />
+        </profile>
+        
+        <!-- HTC Vive Trackers, use fully specified paths -->
+        <profile device="/interaction_profiles/htc/vive_tracker_htcx" extension="XR_HTCX_vive_tracker_interaction">
+            <bind action="left_foot" path="/user/vive_tracker_htcx/role/left_foot/input/grip/pose" />
+            <bind action="right_foot" path="/user/vive_tracker_htcx/role/right_foot/input/grip/pose" />
+            <bind action="waist" path="/user/vive_tracker_htcx/role/waist/input/grip/pose" />
         </profile>
     </actionset>
 </xr_manifest>


### PR DESCRIPTION
See title. Main change is that hands/aims aren't treated as special when updating tracking, all pose actions are located if they are actively bound. Aside from this, all other matters related to hands/aims are unaffected.