### PR TITLE
add headers for gcc

### DIFF
--- a/Source/ThirdParty/crunch/include/crunch/crn_decomp.h
+++ b/Source/ThirdParty/crunch/include/crunch/crn_decomp.h
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <cstdint>
 #ifdef WIN32
 #include <memory.h>
 #elif __APPLE__

--- a/Source/ThirdParty/libdatachannel/src/impl/wshandshake.hpp
+++ b/Source/ThirdParty/libdatachannel/src/impl/wshandshake.hpp
@@ -16,6 +16,7 @@
 #include <list>
 #include <map>
 #include <vector>
+#include <stdexcept>
 
 namespace rtc::impl {
 


### PR DESCRIPTION
Hey!
I'm having problems to build engine with gcc.
I solved it by adding header files in two places.

The problem places were here:
[1.txt](https://github.com/rbfx/rbfx/files/13689204/1.txt)
[2.txt](https://github.com/rbfx/rbfx/files/13689207/2.txt)


I don't know how correct it is to edit third-party engine's libraries. At least for the sake of history then. 