### PR TITLE
Servercrashes when client disconnect

### DIFF
--- a/Source/Urho3D/Network/Transport/DataChannel/DataChannelConnection.cpp
+++ b/Source/Urho3D/Network/Transport/DataChannel/DataChannelConnection.cpp
@@ -67,9 +67,9 @@ bool DataChannelConnection::Connect(const URL& url)
 
 void DataChannelConnection::Disconnect()
 {
+    AddRef(); // Ensure this object is alive until all callbacks are done executing.
     if (peer_)
     {
-        AddRef();    // Ensure this object is alive until all callbacks are done executing.
         state_ = State::Disconnecting;
 #ifndef URHO3D_PLATFORM_WEB
         peer_->resetCallbacks();


### PR DESCRIPTION
if (peer_) can be false and without AddRef(); - ReleaseRef(); in void
 DataChannelConnection::OnDataChannelDisconnected(int index) caused crashes.