### PR TITLE
Refactor navigation mesh design.

### DIFF
--- a/Source/Samples/106_BakedLighting/BakedLighting.cpp
+++ b/Source/Samples/106_BakedLighting/BakedLighting.cpp
@@ -82,7 +82,7 @@ void BakedLighting::CreateScene()
     GetSubsystem<Renderer>()->SetViewport(0, new Viewport(context_, scene_, camera));
 
     auto navMesh = scene_->GetComponent<NavigationMesh>(true);
-    navMesh->Build();
+    navMesh->Rebuild();
 
     agent_ = scene_->GetComponent<CrowdAgent>(true);
     agent_->SetUpdateNodePosition(false);

--- a/Source/Tests/Navigation/Navigation.cpp
+++ b/Source/Tests/Navigation/Navigation.cpp
@@ -131,7 +131,7 @@ TEST_CASE("Recast/Detour Crowdmanager test with DynamicNavigationMesh")
     // Now build the navigation geometry. This will take some time. Note that the navigation mesh will prefer to use
     // physics geometry from the scene nodes, as it often is simpler, but if it can not find any (like in this example)
     // it will use renderable geometry instead
-    navMesh->Build();
+    navMesh->Rebuild();
 
     // Create a CrowdManager component to the scene root
     auto* crowdManager = scene->CreateComponent<CrowdManager>();
@@ -169,7 +169,7 @@ TEST_CASE("Recast/Detour Crowdmanager test with DynamicNavigationMesh")
     for (unsigned i = 0; i < testAgents.size(); ++i)
     {
         Vector3 randomTargetPos = Vector3(Random(60.0f) - 30.0f, 0.0f, Random(60.0f) - 30.0f);
-        //find a new targetposition with range > boxNode size+      
+        //find a new targetposition with range > boxNode size+
         Vector3 pathPos = navMesh->FindNearestPoint(randomTargetPos, Vector3(15.0f, 1.0f, 15.0f));
         crowdManager->SetCrowdTarget(pathPos, testAgents[i].crowdAgentNode);
     }

--- a/Source/Urho3D/Navigation/CrowdAgent.cpp
+++ b/Source/Urho3D/Navigation/CrowdAgent.cpp
@@ -657,9 +657,8 @@ void CrowdAgent::HandleNavigationTileAdded(StringHash eventType, VariantMap& eve
     if (crowdManager_->GetNavigationMesh() != mesh)
         return;
 
-    const IntVector2 tile = eventData[NavigationTileRemoved::P_TILE].GetIntVector2();
+    const IntVector2 tile = eventData[NavigationTileAdded::P_TILE].GetIntVector2();
     const IntVector2 agentTile = mesh->GetTileIndex(node_->GetWorldPosition());
-    const BoundingBox boundingBox = mesh->GetTileBoundingBox(agentTile);
     if (tile == agentTile && IsInCrowd())
     {
         RemoveAgentFromCrowd();

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -217,8 +217,6 @@ DynamicNavigationMesh::DynamicNavigationMesh(Context* context) :
     NavigationMesh(context),
     maxLayers_(DEFAULT_MAX_LAYERS)
 {
-    // 64 is the largest tile-size that DetourTileCache will tolerate without silently failing
-    tileSize_ = 64;
     partitionType_ = NAVMESH_PARTITION_MONOTONE;
     allocator_ = ea::make_unique<LinearAllocator>(32 * 1024);
     compressor_ = ea::make_unique<TileCompressor>();

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -590,7 +590,8 @@ int DynamicNavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometr
     tileCache_->removeTile(navMesh_->getTileRefAt(x, z, 0), nullptr, nullptr);
 
     const BoundingBox tileColumn = GetTileBoundingBoxColumn(IntVector2{x, z});
-    const BoundingBox tileBoundingBox = CalculateTileBoundingBox(geometryList, tileColumn);
+    const BoundingBox tileBoundingBox =
+        IsHeightRangeValid() ? tileColumn : CalculateTileBoundingBox(geometryList, tileColumn);
 
     DynamicNavBuildData build(allocator_.get());
 

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -33,6 +33,7 @@
 #include "../Navigation/NavArea.h"
 #include "../Navigation/NavBuildData.h"
 #include "../Navigation/NavigationEvents.h"
+#include "../Navigation/NavigationUtils.h"
 #include "../Navigation/Obstacle.h"
 #include "../Navigation/OffMeshConnection.h"
 #include "../Scene/Node.h"
@@ -235,55 +236,14 @@ void DynamicNavigationMesh::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Draw Obstacles", GetDrawObstacles, SetDrawObstacles, bool, false, AM_DEFAULT);
 }
 
-bool DynamicNavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned maxTiles)
+bool DynamicNavigationMesh::AllocateMesh(unsigned maxTiles)
 {
-    // Release existing navigation data and zero the bounding box
-    ReleaseNavigationMesh();
-
-    if (!node_)
+    if (!NavigationMesh::AllocateMesh(maxTiles * maxLayers_))
         return false;
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    boundingBox_ = boundingBox.Transformed(node_->GetWorldTransform().Inverse());
-    maxTiles = NextPowerOfTwo(maxTiles);
-
-    // Calculate number of tiles
-    int gridW = 0, gridH = 0;
-    float tileEdgeLength = (float)tileSize_ * cellSize_;
-    rcCalcGridSize(&boundingBox_.min_.x_, &boundingBox_.max_.x_, cellSize_, &gridW, &gridH);
-    numTilesX_ = (gridW + tileSize_ - 1) / tileSize_;
-    numTilesZ_ = (gridH + tileSize_ - 1) / tileSize_;
-
-    // Calculate max number of polygons, 22 bits available to identify both tile & polygon within tile
-    unsigned tileBits = LogBaseTwo(maxTiles);
-    unsigned maxPolys = 1u << (22 - tileBits);
-
-    dtNavMeshParams params;     // NOLINT(hicpp-member-init)
-    rcVcopy(params.orig, &boundingBox_.min_.x_);
-    params.tileWidth = tileEdgeLength;
-    params.tileHeight = tileEdgeLength;
-    params.maxTiles = maxTiles;
-    params.maxPolys = maxPolys;
-
-    navMesh_ = dtAllocNavMesh();
-    if (!navMesh_)
-    {
-        URHO3D_LOGERROR("Could not allocate navigation mesh");
-        return false;
-    }
-
-    if (dtStatusFailed(navMesh_->init(&params)))
-    {
-        URHO3D_LOGERROR("Could not initialize navigation mesh");
-        ReleaseNavigationMesh();
-        return false;
-    }
 
     dtTileCacheParams tileCacheParams;      // NOLINT(hicpp-member-init)
     memset(&tileCacheParams, 0, sizeof(tileCacheParams));
-    rcVcopy(tileCacheParams.orig, &boundingBox_.min_.x_);
+    // TODO: Fill tileCacheParams.orig
     tileCacheParams.ch = cellHeight_;
     tileCacheParams.cs = cellSize_;
     tileCacheParams.width = tileSize_;
@@ -311,7 +271,14 @@ bool DynamicNavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned ma
         return false;
     }
 
-    URHO3D_LOGDEBUG("Allocated empty navigation mesh with max " + ea::to_string(maxTiles) + " tiles");
+    // No need to scan for obstacles here because there are no tiles yet
+    return true;
+}
+
+bool DynamicNavigationMesh::RebuildMesh()
+{
+    if (!NavigationMesh::RebuildMesh())
+        return false;
 
     // Scan for obstacles to insert into us
     ea::vector<Node*> obstacles;
@@ -323,231 +290,26 @@ bool DynamicNavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned ma
             AddObstacle(obs);
     }
 
-    // Send a notification event to concerned parties that we've been fully rebuilt
-    {
-        using namespace NavigationMeshRebuilt;
-        VariantMap& buildEventParams = GetContext()->GetEventDataMap();
-        buildEventParams[P_NODE] = node_;
-        buildEventParams[P_MESH] = this;
-        SendEvent(E_NAVIGATION_MESH_REBUILT, buildEventParams);
-    }
     return true;
 }
 
-bool DynamicNavigationMesh::Build()
+ea::vector<unsigned char> DynamicNavigationMesh::GetTileData(const IntVector2& tileIndex) const
 {
-    URHO3D_PROFILE("BuildNavigationMesh");
-    // Release existing navigation data and zero the bounding box
-    ReleaseNavigationMesh();
+    dtCompressedTileRef tiles[TILECACHE_MAXLAYERS];
+    const int numTiles = tileCache_->getTilesAt(tileIndex.x_, tileIndex.y_, tiles, maxLayers_);
 
-    if (!node_)
-        return false;
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    ea::vector<NavigationGeometryInfo> geometryList;
-    CollectGeometries(geometryList);
-
-    if (geometryList.empty())
-        return true; // Nothing to do
-
-    // Build the combined bounding box
-    for (unsigned i = 0; i < geometryList.size(); ++i)
-        boundingBox_.Merge(geometryList[i].boundingBox_);
-
-    // Expand bounding box by padding
-    boundingBox_.min_ -= padding_;
-    boundingBox_.max_ += padding_;
-
-    {
-        URHO3D_PROFILE("BuildNavigationMesh");
-
-        // Calculate number of tiles
-        int gridW = 0, gridH = 0;
-        float tileEdgeLength = (float)tileSize_ * cellSize_;
-        rcCalcGridSize(&boundingBox_.min_.x_, &boundingBox_.max_.x_, cellSize_, &gridW, &gridH);
-        numTilesX_ = (gridW + tileSize_ - 1) / tileSize_;
-        numTilesZ_ = (gridH + tileSize_ - 1) / tileSize_;
-
-        // Calculate max. number of tiles and polygons, 22 bits available to identify both tile & polygon within tile
-        unsigned maxTiles = NextPowerOfTwo((unsigned)(numTilesX_ * numTilesZ_)) * maxLayers_;
-        unsigned tileBits = LogBaseTwo(maxTiles);
-        unsigned maxPolys = 1u << (22 - tileBits);
-
-        dtNavMeshParams params;     // NOLINT(hicpp-member-init)
-        rcVcopy(params.orig, &boundingBox_.min_.x_);
-        params.tileWidth = tileEdgeLength;
-        params.tileHeight = tileEdgeLength;
-        params.maxTiles = maxTiles;
-        params.maxPolys = maxPolys;
-
-        navMesh_ = dtAllocNavMesh();
-        if (!navMesh_)
-        {
-            URHO3D_LOGERROR("Could not allocate navigation mesh");
-            return false;
-        }
-
-        if (dtStatusFailed(navMesh_->init(&params)))
-        {
-            URHO3D_LOGERROR("Could not initialize navigation mesh");
-            ReleaseNavigationMesh();
-            return false;
-        }
-
-        dtTileCacheParams tileCacheParams;      // NOLINT(hicpp-member-init)
-        memset(&tileCacheParams, 0, sizeof(tileCacheParams));
-        rcVcopy(tileCacheParams.orig, &boundingBox_.min_.x_);
-        tileCacheParams.ch = cellHeight_;
-        tileCacheParams.cs = cellSize_;
-        tileCacheParams.width = tileSize_;
-        tileCacheParams.height = tileSize_;
-        tileCacheParams.maxSimplificationError = edgeMaxError_;
-        tileCacheParams.maxTiles = numTilesX_ * numTilesZ_ * maxLayers_;
-        tileCacheParams.maxObstacles = maxObstacles_;
-        // Settings from NavigationMesh
-        tileCacheParams.walkableClimb = agentMaxClimb_;
-        tileCacheParams.walkableHeight = agentHeight_;
-        tileCacheParams.walkableRadius = agentRadius_;
-
-        tileCache_ = dtAllocTileCache();
-        if (!tileCache_)
-        {
-            URHO3D_LOGERROR("Could not allocate tile cache");
-            ReleaseNavigationMesh();
-            return false;
-        }
-
-        if (dtStatusFailed(tileCache_->init(&tileCacheParams, allocator_.get(), compressor_.get(), meshProcessor_.get())))
-        {
-            URHO3D_LOGERROR("Could not initialize tile cache");
-            ReleaseNavigationMesh();
-            return false;
-        }
-
-        // Build each tile
-        unsigned numTiles = 0;
-
-        for (int z = 0; z < numTilesZ_; ++z)
-        {
-            for (int x = 0; x < numTilesX_; ++x)
-            {
-                TileCacheData tiles[TILECACHE_MAXLAYERS];
-                int layerCt = BuildTile(geometryList, x, z, tiles);
-                for (int i = 0; i < layerCt; ++i)
-                {
-                    dtCompressedTileRef tileRef;
-                    int status = tileCache_->addTile(tiles[i].data, tiles[i].dataSize, DT_COMPRESSEDTILE_FREE_DATA, &tileRef);
-                    if (dtStatusFailed((dtStatus)status))
-                    {
-                        dtFree(tiles[i].data);
-                        tiles[i].data = nullptr;
-                    }
-                }
-                tileCache_->buildNavMeshTilesAt(x, z, navMesh_);
-                ++numTiles;
-            }
-        }
-
-        // For a full build it's necessary to update the nav mesh
-        // not doing so will cause dependent components to crash, like CrowdManager
-        tileCache_->update(0, navMesh_);
-
-        URHO3D_LOGDEBUG("Built navigation mesh with " + ea::to_string(numTiles) + " tiles");
-
-        // Send a notification event to concerned parties that we've been fully rebuilt
-        {
-            using namespace NavigationMeshRebuilt;
-            VariantMap& buildEventParams = GetContext()->GetEventDataMap();
-            buildEventParams[P_NODE] = node_;
-            buildEventParams[P_MESH] = this;
-            SendEvent(E_NAVIGATION_MESH_REBUILT, buildEventParams);
-        }
-
-        // Scan for obstacles to insert into us
-        ea::vector<Node*> obstacles;
-        GetScene()->GetChildrenWithComponent<Obstacle>(obstacles, true);
-        for (unsigned i = 0; i < obstacles.size(); ++i)
-        {
-            auto* obs = obstacles[i]->GetComponent<Obstacle>();
-            if (obs && obs->IsEnabledEffective())
-                AddObstacle(obs);
-        }
-
-        return true;
-    }
-}
-
-bool DynamicNavigationMesh::Build(const BoundingBox& boundingBox)
-{
-    URHO3D_PROFILE("BuildPartialNavigationMesh");
-
-    if (!node_)
-        return false;
-
-    if (!navMesh_)
-    {
-        URHO3D_LOGERROR("Navigation mesh must first be built fully before it can be partially rebuilt");
-        return false;
-    }
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    BoundingBox localSpaceBox = boundingBox.Transformed(node_->GetWorldTransform().Inverse());
-
-    float tileEdgeLength = (float)tileSize_ * cellSize_;
-
-    ea::vector<NavigationGeometryInfo> geometryList;
-    CollectGeometries(geometryList);
-
-    int sx = Clamp((int)((localSpaceBox.min_.x_ - boundingBox_.min_.x_) / tileEdgeLength), 0, numTilesX_ - 1);
-    int sz = Clamp((int)((localSpaceBox.min_.z_ - boundingBox_.min_.z_) / tileEdgeLength), 0, numTilesZ_ - 1);
-    int ex = Clamp((int)((localSpaceBox.max_.x_ - boundingBox_.min_.x_) / tileEdgeLength), 0, numTilesX_ - 1);
-    int ez = Clamp((int)((localSpaceBox.max_.z_ - boundingBox_.min_.z_) / tileEdgeLength), 0, numTilesZ_ - 1);
-
-    unsigned numTiles = BuildTiles(geometryList, IntVector2(sx, sz), IntVector2(ex, ez));
-
-    URHO3D_LOGDEBUG("Rebuilt " + ea::to_string(numTiles) + " tiles of the navigation mesh");
-    return true;
-}
-
-bool DynamicNavigationMesh::Build(const IntVector2& from, const IntVector2& to)
-{
-    URHO3D_PROFILE("BuildPartialNavigationMesh");
-
-    if (!node_)
-        return false;
-
-    if (!navMesh_)
-    {
-        URHO3D_LOGERROR("Navigation mesh must first be built fully before it can be partially rebuilt");
-        return false;
-    }
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    ea::vector<NavigationGeometryInfo> geometryList;
-    CollectGeometries(geometryList);
-
-    unsigned numTiles = BuildTiles(geometryList, from, to);
-
-    URHO3D_LOGDEBUG("Rebuilt " + ea::to_string(numTiles) + " tiles of the navigation mesh");
-    return true;
-}
-
-ea::vector<unsigned char> DynamicNavigationMesh::GetTileData(const IntVector2& tile) const
-{
     VectorBuffer ret;
-    WriteTiles(ret, tile.x_, tile.y_);
+    for (int i = 0; i < numTiles; ++i)
+    {
+        const dtCompressedTile* tile = tileCache_->getTileByRef(tiles[i]);
+        WriteTile(ret, tileIndex.x_, tileIndex.y_, tile->header->tlayer);
+    }
     return ret.GetBuffer();
 }
 
-bool DynamicNavigationMesh::IsObstacleInTile(Obstacle* obstacle, const IntVector2& tile) const
+bool DynamicNavigationMesh::IsObstacleInTile(Obstacle* obstacle, const IntVector2& tileIndex) const
 {
-    const BoundingBox tileBoundingBox = GetTileBoundingBox(tile);
+    const BoundingBox tileBoundingBox = GetTileBoundingBoxColumn(tileIndex);
     const Vector3 obstaclePosition = obstacle->GetNode()->GetWorldPosition();
     return tileBoundingBox.DistanceToPoint(obstaclePosition) < obstacle->GetRadius();
 }
@@ -558,13 +320,13 @@ bool DynamicNavigationMesh::AddTile(const ea::vector<unsigned char>& tileData)
     return ReadTiles(buffer, false);
 }
 
-void DynamicNavigationMesh::RemoveTile(const IntVector2& tile)
+void DynamicNavigationMesh::RemoveTile(const IntVector2& tileIndex)
 {
     if (!navMesh_)
         return;
 
     dtCompressedTileRef existing[TILECACHE_MAXLAYERS];
-    const int existingCt = tileCache_->getTilesAt(tile.x_, tile.y_, existing, maxLayers_);
+    const int existingCt = tileCache_->getTilesAt(tileIndex.x_, tileIndex.y_, existing, maxLayers_);
     for (int i = 0; i < existingCt; ++i)
     {
         unsigned char* data = nullptr;
@@ -572,7 +334,7 @@ void DynamicNavigationMesh::RemoveTile(const IntVector2& tile)
             dtFree(data);
     }
 
-    NavigationMesh::RemoveTile(tile);
+    NavigationMesh::RemoveTile(tileIndex);
 }
 
 void DynamicNavigationMesh::RemoveAllTiles()
@@ -680,9 +442,17 @@ void DynamicNavigationMesh::SetNavigationDataAttr(const ea::vector<unsigned char
         return;
 
     MemoryBuffer buffer(value);
-    boundingBox_ = buffer.ReadBoundingBox();
-    numTilesX_ = buffer.ReadInt();
-    numTilesZ_ = buffer.ReadInt();
+
+    // Keep the header the same as the old data format to check for validity.
+    buffer.ReadBoundingBox();
+    const int unused0 = buffer.ReadInt();
+    const int unused1 = buffer.ReadInt();
+    const int version = buffer.ReadInt();
+    if (unused0 != 0 || unused1 != 0 || version != NavigationDataVersion)
+    {
+        URHO3D_LOGWARNING("Incompatible navigation data format, please rebuild navigation data");
+        return;
+    }
 
     dtNavMeshParams params;     // NOLINT(hicpp-member-init)
     buffer.Read(&params, sizeof(dtNavMeshParams));
@@ -727,9 +497,10 @@ ea::vector<unsigned char> DynamicNavigationMesh::GetNavigationDataAttr() const
     VectorBuffer ret;
     if (navMesh_ && tileCache_)
     {
-        ret.WriteBoundingBox(boundingBox_);
-        ret.WriteInt(numTilesX_);
-        ret.WriteInt(numTilesZ_);
+        ret.WriteBoundingBox(BoundingBox{});
+        ret.WriteInt(0);
+        ret.WriteInt(0);
+        ret.WriteInt(NavigationDataVersion);
 
         const dtNavMeshParams* params = navMesh_->getParams();
         ret.Write(params, sizeof(dtNavMeshParams));
@@ -737,9 +508,14 @@ ea::vector<unsigned char> DynamicNavigationMesh::GetNavigationDataAttr() const
         const dtTileCacheParams* tcParams = tileCache_->getParams();
         ret.Write(tcParams, sizeof(dtTileCacheParams));
 
-        for (int z = 0; z < numTilesZ_; ++z)
-            for (int x = 0; x < numTilesX_; ++x)
-                WriteTiles(ret, x, z);
+        for (int i = 0; i < navMesh_->getMaxTiles(); ++i)
+        {
+            const dtMeshTile* tile = const_cast<const dtNavMesh*>(navMesh_)->getTile(i);
+            if (!tile || !tile->header || !tile->dataSize)
+                continue;
+
+            WriteTile(ret, tile->header->x, tile->header->y, tile->header->layer);
+        }
     }
     return ret.GetBuffer();
 }
@@ -751,20 +527,17 @@ void DynamicNavigationMesh::SetMaxLayers(unsigned maxLayers)
     maxLayers_ = Max(3U, Min(maxLayers, TILECACHE_MAXLAYERS));
 }
 
-void DynamicNavigationMesh::WriteTiles(Serializer& dest, int x, int z) const
+void DynamicNavigationMesh::WriteTile(Serializer& dest, int x, int z, int layer) const
 {
-    dtCompressedTileRef tiles[TILECACHE_MAXLAYERS];
-    const int ct = tileCache_->getTilesAt(x, z, tiles, maxLayers_);
-    for (int i = 0; i < ct; ++i)
-    {
-        const dtCompressedTile* tile = tileCache_->getTileByRef(tiles[i]);
-        if (!tile || !tile->header || !tile->dataSize)
-            continue; // Don't write "void-space" tiles
-                      // The header conveniently has the majority of the information required
-        dest.Write(tile->header, sizeof(dtTileCacheLayerHeader));
-        dest.WriteInt(tile->dataSize);
-        dest.Write(tile->data, (unsigned)tile->dataSize);
-    }
+    // Don't write "void-space" tiles
+    const dtCompressedTile* tile = tileCache_->getTileAt(x, z, layer);
+    if (!tile || !tile->header || !tile->dataSize)
+        return;
+
+    // The header conveniently has the majority of the information required
+    dest.Write(tile->header, sizeof(dtTileCacheLayerHeader));
+    dest.WriteInt(tile->dataSize);
+    dest.Write(tile->data, static_cast<unsigned>(tile->dataSize));
 }
 
 bool DynamicNavigationMesh::ReadTiles(Deserializer& source, bool silent)
@@ -799,20 +572,11 @@ bool DynamicNavigationMesh::ReadTiles(Deserializer& source, bool silent)
     for (unsigned i = 0; i < tileQueue_.size(); ++i)
         tileCache_->buildNavMeshTilesAt(tileQueue_[i].x_, tileQueue_[i].y_, navMesh_);
 
-    tileCache_->update(0, navMesh_);
-
     // Send event
     if (!silent)
     {
-        for (unsigned i = 0; i < tileQueue_.size(); ++i)
-        {
-            using namespace NavigationTileAdded;
-            VariantMap& eventData = GetContext()->GetEventDataMap();
-            eventData[P_NODE] = GetNode();
-            eventData[P_MESH] = this;
-            eventData[P_TILE] = tileQueue_[i];
-            SendEvent(E_NAVIGATION_TILE_ADDED, eventData);
-        }
+        for (const IntVector2& tileIndex : tileQueue_)
+            SendTileAddedEvent(tileIndex);
     }
     return true;
 }
@@ -823,12 +587,13 @@ int DynamicNavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometr
 
     tileCache_->removeTile(navMesh_->getTileRefAt(x, z, 0), nullptr, nullptr);
 
-    const BoundingBox tileBoundingBox = GetTileBoundingBox(IntVector2(x, z));
+    const BoundingBox tileColumn = GetTileBoundingBoxColumn(IntVector2{x, z});
+    const BoundingBox tileBoundingBox = CalculateTileBoundingBox(geometryList, tileColumn);
 
     DynamicNavBuildData build(allocator_.get());
 
     rcConfig cfg;   // NOLINT(hicpp-member-init)
-    memset(&cfg, 0, sizeof cfg);
+    memset(&cfg, 0, sizeof(cfg));
     cfg.cs = cellSize_;
     cfg.ch = cellHeight_;
     cfg.walkableSlopeAngle = agentMaxSlope_;
@@ -850,8 +615,10 @@ int DynamicNavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometr
     rcVcopy(cfg.bmin, &tileBoundingBox.min_.x_);
     rcVcopy(cfg.bmax, &tileBoundingBox.max_.x_);
     cfg.bmin[0] -= cfg.borderSize * cfg.cs;
+    cfg.bmin[1] -= padding_.y_;
     cfg.bmin[2] -= cfg.borderSize * cfg.cs;
     cfg.bmax[0] += cfg.borderSize * cfg.cs;
+    cfg.bmax[1] += padding_.y_;
     cfg.bmax[2] += cfg.borderSize * cfg.cs;
 
     BoundingBox expandedBox(*reinterpret_cast<Vector3*>(cfg.bmin), *reinterpret_cast<Vector3*>(cfg.bmax));
@@ -996,7 +763,8 @@ int DynamicNavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometr
     return retCt;
 }
 
-unsigned DynamicNavigationMesh::BuildTiles(ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to)
+unsigned DynamicNavigationMesh::BuildTilesFromGeometry(
+    ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to)
 {
     unsigned numTiles = 0;
 
@@ -1066,6 +834,15 @@ void DynamicNavigationMesh::ReleaseTileCache()
     tileCache_ = nullptr;
 }
 
+void DynamicNavigationMesh::UpdateTileCache()
+{
+    bool upToDate = false;
+    do
+    {
+        tileCache_->update(0, navMesh_, &upToDate);
+    } while (!upToDate);
+}
+
 void DynamicNavigationMesh::OnSceneSet(Scene* scene)
 {
     // Subscribe to the scene subsystem update, which will trigger the tile cache to update the nav mesh
@@ -1086,8 +863,7 @@ void DynamicNavigationMesh::AddObstacle(Obstacle* obstacle, bool silent)
 
         // Because dtTileCache doesn't process obstacle requests while updating tiles
         // it's necessary update until sufficient request space is available
-        while (tileCache_->isObstacleQueueFull())
-            tileCache_->update(1, navMesh_);
+        UpdateTileCache();
 
         if (dtStatusFailed(tileCache_->addObstacle(pos, obstacle->GetRadius(), obstacle->GetHeight(), &refHolder)))
         {
@@ -1126,8 +902,7 @@ void DynamicNavigationMesh::RemoveObstacle(Obstacle* obstacle, bool silent)
     {
         // Because dtTileCache doesn't process obstacle requests while updating tiles
         // it's necessary update until sufficient request space is available
-        while (tileCache_->isObstacleQueueFull())
-            tileCache_->update(1, navMesh_);
+        UpdateTileCache();
 
         if (dtStatusFailed(tileCache_->removeObstacle(obstacle->obstacleId_)))
         {
@@ -1155,7 +930,7 @@ void DynamicNavigationMesh::HandleSceneSubsystemUpdate(StringHash eventType, Var
     using namespace SceneSubsystemUpdate;
 
     if (tileCache_ && navMesh_ && IsEnabledEffective())
-        tileCache_->update(eventData[P_TIMESTEP].GetFloat(), navMesh_);
+        UpdateTileCache();
 }
 
 }

--- a/Source/Urho3D/Navigation/NavigationDefs.h
+++ b/Source/Urho3D/Navigation/NavigationDefs.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef DT_POLYREF64
+using dtPolyRef = uint64_t;
+#else
+using dtPolyRef = unsigned int;
+#endif

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -146,6 +146,7 @@ void NavigationMesh::RegisterObject(Context* context)
     context->AddFactoryReflection<NavigationMesh>(Category_Navigation);
 
     URHO3D_ACTION_STATIC_LABEL("Rebuild!", Rebuild, "Rebuilds navigation mesh and adjusts maximum number of tiles");
+    URHO3D_ACTION_STATIC_LABEL("Allocate!", Allocate, "Allocates empty navigation mesh with specified maximum number of tiles");
 
     URHO3D_ACCESSOR_ATTRIBUTE("Max Tiles", GetMaxTiles, SetMaxTiles, int, DefaultMaxTiles, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Tile Size", GetTileSize, SetTileSize, int, DEFAULT_TILE_SIZE, AM_DEFAULT);

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -40,6 +40,7 @@
 #include "../Navigation/Navigable.h"
 #include "../Navigation/NavigationEvents.h"
 #include "../Navigation/NavigationMesh.h"
+#include "../Navigation/NavigationUtils.h"
 #include "../Navigation/Obstacle.h"
 #include "../Navigation/OffMeshConnection.h"
 #ifdef URHO3D_PHYSICS
@@ -81,7 +82,6 @@ static const float DEFAULT_DETAIL_SAMPLE_MAX_ERROR = 1.0f;
 
 static const int MAX_POLYS = 2048;
 
-
 /// Temporary data for finding a path.
 struct FindPathData
 {
@@ -94,6 +94,20 @@ struct FindPathData
     // Flags on the path.
     unsigned char pathFlags_[MAX_POLYS]{};
 };
+
+namespace
+{
+
+/// Write dtMeshTile to the stream.
+void WriteTile(Serializer& dest, const dtMeshTile* tile)
+{
+    dest.WriteInt(tile->header->x);
+    dest.WriteInt(tile->header->y);
+    dest.WriteInt(tile->dataSize);
+    dest.Write(tile->data, static_cast<unsigned>(tile->dataSize));
+}
+
+} // namespace
 
 NavigationMesh::NavigationMesh(Context* context) :
     Component(context),
@@ -115,8 +129,6 @@ NavigationMesh::NavigationMesh(Context* context) :
     detailSampleDistance_(DEFAULT_DETAIL_SAMPLE_DISTANCE),
     detailSampleMaxError_(DEFAULT_DETAIL_SAMPLE_MAX_ERROR),
     padding_(Vector3::ONE),
-    numTilesX_(0),
-    numTilesZ_(0),
     partitionType_(NAVMESH_PARTITION_WATERSHED),
     keepInterResults_(false),
     drawOffMeshConnections_(false),
@@ -133,8 +145,9 @@ void NavigationMesh::RegisterObject(Context* context)
 {
     context->AddFactoryReflection<NavigationMesh>(Category_Navigation);
 
-    URHO3D_ACTION_STATIC_LABEL("Build!", Build, "(Re)builds navigation mesh");
+    URHO3D_ACTION_STATIC_LABEL("Rebuild!", Rebuild, "Rebuilds navigation mesh and adjusts maximum number of tiles");
 
+    URHO3D_ACCESSOR_ATTRIBUTE("Max Tiles", GetMaxTiles, SetMaxTiles, int, DefaultMaxTiles, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Tile Size", GetTileSize, SetTileSize, int, DEFAULT_TILE_SIZE, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Cell Size", GetCellSize, SetCellSize, float, DEFAULT_CELL_SIZE, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Cell Height", GetCellHeight, SetCellHeight, float, DEFAULT_CELL_HEIGHT, AM_DEFAULT);
@@ -294,33 +307,21 @@ void NavigationMesh::SetPadding(const Vector3& padding)
     padding_ = padding;
 }
 
-bool NavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned maxTiles)
+bool NavigationMesh::AllocateMesh(unsigned maxTiles)
 {
-    // Release existing navigation data and zero the bounding box
+    // Release existing navigation data
     ReleaseNavigationMesh();
 
     if (!node_)
         return false;
 
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    boundingBox_ = boundingBox.Transformed(node_->GetWorldTransform().Inverse());
-    maxTiles = NextPowerOfTwo(maxTiles);
-
-    // Calculate number of tiles
-    int gridW = 0, gridH = 0;
-    float tileEdgeLength = (float)tileSize_ * cellSize_;
-    rcCalcGridSize(&boundingBox_.min_.x_, &boundingBox_.max_.x_, cellSize_, &gridW, &gridH);
-    numTilesX_ = (gridW + tileSize_ - 1) / tileSize_;
-    numTilesZ_ = (gridH + tileSize_ - 1) / tileSize_;
-
     // Calculate max number of polygons, 22 bits available to identify both tile & polygon within tile
-    unsigned tileBits = LogBaseTwo(maxTiles);
-    unsigned maxPolys = 1u << (22 - tileBits);
+    const unsigned tileBits = LogBaseTwo(maxTiles);
+    const unsigned maxPolys = 1u << (22 - tileBits);
+    const float tileEdgeLength = tileSize_ * cellSize_;
 
-    dtNavMeshParams params;     // NOLINT(hicpp-member-init)
-    rcVcopy(params.orig, &boundingBox_.min_.x_);
+    dtNavMeshParams params{};
+    // TODO: Fill params.orig
     params.tileWidth = tileEdgeLength;
     params.tileHeight = tileEdgeLength;
     params.maxTiles = maxTiles;
@@ -340,101 +341,88 @@ bool NavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned maxTiles)
         return false;
     }
 
-    URHO3D_LOGDEBUG("Allocated empty navigation mesh with max " + ea::to_string(maxTiles) + " tiles");
-
-    // Send a notification event to concerned parties that we've been fully rebuilt
-    {
-        using namespace NavigationMeshRebuilt;
-        VariantMap& buildEventParams = GetContext()->GetEventDataMap();
-        buildEventParams[P_NODE] = node_;
-        buildEventParams[P_MESH] = this;
-        SendEvent(E_NAVIGATION_MESH_REBUILT, buildEventParams);
-    }
     return true;
 }
 
-bool NavigationMesh::Build()
+bool NavigationMesh::Allocate()
+{
+    URHO3D_PROFILE("AllocateNavigationMesh");
+
+    if (!AllocateMesh(maxTiles_))
+        return false;
+
+    URHO3D_LOGDEBUG("Allocated empty navigation mesh with max {} tiles", maxTiles_);
+    SendRebuildEvent();
+    return true;
+}
+
+void NavigationMesh::SendRebuildEvent()
+{
+    using namespace NavigationMeshRebuilt;
+    VariantMap& buildEventParams = GetContext()->GetEventDataMap();
+    buildEventParams[P_NODE] = node_;
+    buildEventParams[P_MESH] = this;
+    SendEvent(E_NAVIGATION_MESH_REBUILT, buildEventParams);
+}
+
+bool NavigationMesh::RebuildMesh()
+{
+    // Collect geometry and update dimensions
+    ea::vector<NavigationGeometryInfo> geometryList;
+    CollectGeometries(geometryList);
+
+    const BoundingBox boundingBox = CalculateBoundingBox(geometryList, padding_);
+    const unsigned maxTiles = CalculateMaxTiles(boundingBox, tileSize_, cellSize_);
+
+    maxTiles_ = maxTiles ? static_cast<int>(maxTiles) : DefaultMaxTiles;
+
+    // Allocate navigation mesh
+    if (!AllocateMesh(maxTiles_))
+        return false;
+
+    // Build navigation mesh
+    const IntVector2 beginTileIndex = GetTileIndex(boundingBox.min_);
+    const IntVector2 endTileIndex = GetTileIndex(boundingBox.max_);
+
+    BuildTilesFromGeometry(geometryList, beginTileIndex, endTileIndex);
+    return true;
+}
+
+bool NavigationMesh::Rebuild()
 {
     URHO3D_PROFILE("BuildNavigationMesh");
 
-    // Release existing navigation data and zero the bounding box
-    ReleaseNavigationMesh();
+    if (!RebuildMesh())
+        return false;
+
+    URHO3D_LOGDEBUG("Built navigation mesh with max {} tiles", maxTiles_);
+    SendRebuildEvent();
+    return true;
+}
+
+bool NavigationMesh::BuildTilesInRegion(const BoundingBox& boundingBox)
+{
+    URHO3D_PROFILE("BuildPartialNavigationMesh");
 
     if (!node_)
         return false;
 
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
     ea::vector<NavigationGeometryInfo> geometryList;
     CollectGeometries(geometryList);
 
-    if (geometryList.empty())
-        return true; // Nothing to do
+    const IntVector2 beginTileIndex = GetTileIndex(boundingBox.min_);
+    const IntVector2 endTileIndex = GetTileIndex(boundingBox.max_);
 
-    // Build the combined bounding box
-    for (unsigned i = 0; i < geometryList.size(); ++i)
-        boundingBox_.Merge(geometryList[i].boundingBox_);
+    const unsigned numTiles = BuildTilesFromGeometry(geometryList, beginTileIndex, endTileIndex);
+    URHO3D_LOGDEBUG("Rebuilt {} tiles of the navigation mesh", numTiles);
 
-    // Expand bounding box by padding
-    boundingBox_.min_ -= padding_;
-    boundingBox_.max_ += padding_;
+    for (const IntVector2& tileIndex : IntRect{beginTileIndex, endTileIndex + IntVector2::ONE})
+        SendTileAddedEvent(tileIndex);
 
-    {
-        URHO3D_PROFILE("BuildNavigationMesh");
-
-        // Calculate number of tiles
-        int gridW = 0, gridH = 0;
-        float tileEdgeLength = (float)tileSize_ * cellSize_;
-        rcCalcGridSize(&boundingBox_.min_.x_, &boundingBox_.max_.x_, cellSize_, &gridW, &gridH);
-        numTilesX_ = (gridW + tileSize_ - 1) / tileSize_;
-        numTilesZ_ = (gridH + tileSize_ - 1) / tileSize_;
-
-        // Calculate max. number of tiles and polygons, 22 bits available to identify both tile & polygon within tile
-        unsigned maxTiles = NextPowerOfTwo((unsigned)(numTilesX_ * numTilesZ_));
-        unsigned tileBits = LogBaseTwo(maxTiles);
-        unsigned maxPolys = 1u << (22 - tileBits);
-
-        dtNavMeshParams params;     // NOLINT(hicpp-member-init)
-        rcVcopy(params.orig, &boundingBox_.min_.x_);
-        params.tileWidth = tileEdgeLength;
-        params.tileHeight = tileEdgeLength;
-        params.maxTiles = maxTiles;
-        params.maxPolys = maxPolys;
-
-        navMesh_ = dtAllocNavMesh();
-        if (!navMesh_)
-        {
-            URHO3D_LOGERROR("Could not allocate navigation mesh");
-            return false;
-        }
-
-        if (dtStatusFailed(navMesh_->init(&params)))
-        {
-            URHO3D_LOGERROR("Could not initialize navigation mesh");
-            ReleaseNavigationMesh();
-            return false;
-        }
-
-        // Build each tile
-        unsigned numTiles = BuildTiles(geometryList, IntVector2::ZERO, GetNumTiles() - IntVector2::ONE);
-
-        URHO3D_LOGDEBUG("Built navigation mesh with " + ea::to_string(numTiles) + " tiles");
-
-        // Send a notification event to concerned parties that we've been fully rebuilt
-        {
-            using namespace NavigationMeshRebuilt;
-            VariantMap& buildEventParams = GetContext()->GetEventDataMap();
-            buildEventParams[P_NODE] = node_;
-            buildEventParams[P_MESH] = this;
-            SendEvent(E_NAVIGATION_MESH_REBUILT, buildEventParams);
-        }
-
-        return true;
-    }
+    return true;
 }
 
-bool NavigationMesh::Build(const BoundingBox& boundingBox)
+bool NavigationMesh::BuildTiles(const IntVector2& from, const IntVector2& to)
 {
     URHO3D_PROFILE("BuildPartialNavigationMesh");
 
@@ -443,60 +431,44 @@ bool NavigationMesh::Build(const BoundingBox& boundingBox)
 
     if (!navMesh_)
     {
-        URHO3D_LOGERROR("Navigation mesh must first be built fully before it can be partially rebuilt");
+        URHO3D_LOGERROR("Navigation mesh must first be built or allocated before it can be partially rebuilt");
         return false;
     }
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    BoundingBox localSpaceBox = boundingBox.Transformed(node_->GetWorldTransform().Inverse());
-
-    float tileEdgeLength = (float)tileSize_ * cellSize_;
 
     ea::vector<NavigationGeometryInfo> geometryList;
     CollectGeometries(geometryList);
 
-    int sx = Clamp((int)((localSpaceBox.min_.x_ - boundingBox_.min_.x_) / tileEdgeLength), 0, numTilesX_ - 1);
-    int sz = Clamp((int)((localSpaceBox.min_.z_ - boundingBox_.min_.z_) / tileEdgeLength), 0, numTilesZ_ - 1);
-    int ex = Clamp((int)((localSpaceBox.max_.x_ - boundingBox_.min_.x_) / tileEdgeLength), 0, numTilesX_ - 1);
-    int ez = Clamp((int)((localSpaceBox.max_.z_ - boundingBox_.min_.z_) / tileEdgeLength), 0, numTilesZ_ - 1);
+    unsigned numTiles = BuildTilesFromGeometry(geometryList, from, to);
+    URHO3D_LOGDEBUG("Rebuilt {} tiles of the navigation mesh", numTiles);
 
-    unsigned numTiles = BuildTiles(geometryList, IntVector2(sx, sz), IntVector2(ex, ez));
+    for (const IntVector2& tileIndex : IntRect{from, to + IntVector2::ONE})
+        SendTileAddedEvent(tileIndex);
 
-    URHO3D_LOGDEBUG("Rebuilt " + ea::to_string(numTiles) + " tiles of the navigation mesh");
     return true;
 }
 
-bool NavigationMesh::Build(const IntVector2& from, const IntVector2& to)
+ea::vector<IntVector2> NavigationMesh::GetAllTileIndices() const
 {
-    URHO3D_PROFILE("BuildPartialNavigationMesh");
-
-    if (!node_)
-        return false;
-
-    if (!navMesh_)
+    ea::vector<IntVector2> result;
+    for (int i = 0; i < navMesh_->getMaxTiles(); ++i)
     {
-        URHO3D_LOGERROR("Navigation mesh must first be built fully before it can be partially rebuilt");
-        return false;
+        const dtMeshTile* tile = const_cast<const dtNavMesh*>(navMesh_)->getTile(i);
+        if (!tile->header || !tile->dataSize)
+            continue;
+
+        result.emplace_back(tile->header->x, tile->header->y);
     }
-
-    if (!node_->GetWorldScale().Equals(Vector3::ONE))
-        URHO3D_LOGWARNING("Navigation mesh root node has scaling. Agent parameters may not work as intended");
-
-    ea::vector<NavigationGeometryInfo> geometryList;
-    CollectGeometries(geometryList);
-
-    unsigned numTiles = BuildTiles(geometryList, from, to);
-
-    URHO3D_LOGDEBUG("Rebuilt " + ea::to_string(numTiles) + " tiles of the navigation mesh");
-    return true;
+    return result;
 }
 
-ea::vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const
+ea::vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tileIndex) const
 {
+    const dtMeshTile* tile = navMesh_->getTileAt(tileIndex.x_, tileIndex.y_, 0);
+    if (!tile || !tile->header || !tile->dataSize)
+        return {};
+
     VectorBuffer ret;
-    WriteTile(ret, tile.x_, tile.y_);
+    WriteTile(ret, tile);
     return ret.GetBuffer();
 }
 
@@ -506,43 +478,33 @@ bool NavigationMesh::AddTile(const ea::vector<unsigned char>& tileData)
     return ReadTile(buffer, false);
 }
 
-bool NavigationMesh::HasTile(const IntVector2& tile) const
+bool NavigationMesh::HasTile(const IntVector2& tileIndex) const
 {
     if (navMesh_)
-        return !!navMesh_->getTileAt(tile.x_, tile.y_, 0);
+        return !!navMesh_->getTileAt(tileIndex.x_, tileIndex.y_, 0);
     return false;
 }
 
-BoundingBox NavigationMesh::GetTileBoundingBox(const IntVector2& tile) const
+BoundingBox NavigationMesh::GetTileBoundingBoxColumn(const IntVector2& tileIndex) const
 {
-    const float tileEdgeLength = (float)tileSize_ * cellSize_;
-    return BoundingBox(
-        Vector3(
-            boundingBox_.min_.x_ + tileEdgeLength * (float)tile.x_,
-            boundingBox_.min_.y_,
-            boundingBox_.min_.z_ + tileEdgeLength * (float)tile.y_
-        ),
-        Vector3(
-            boundingBox_.min_.x_ + tileEdgeLength * (float)(tile.x_ + 1),
-            boundingBox_.max_.y_,
-            boundingBox_.min_.z_ + tileEdgeLength * (float)(tile.y_ + 1)
-        ));
+    const float tileEdgeLength = tileSize_ * cellSize_;
+    const Vector3 minPosition{tileIndex.x_ * tileEdgeLength, -M_LARGE_VALUE, tileIndex.y_ * tileEdgeLength};
+    const Vector3 maxPosition{(tileIndex.x_ + 1) * tileEdgeLength, M_LARGE_VALUE, (tileIndex.y_ + 1) * tileEdgeLength};
+    return BoundingBox{minPosition, maxPosition};
 }
 
 IntVector2 NavigationMesh::GetTileIndex(const Vector3& position) const
 {
-    const float tileEdgeLength = (float)tileSize_ * cellSize_;
-    const Vector3 localPosition = node_->GetWorldTransform().Inverse() * position - boundingBox_.min_;
-    const Vector2 localPosition2D(localPosition.x_, localPosition.z_);
-    return VectorMin(VectorMax(IntVector2::ZERO, VectorFloorToInt(localPosition2D / tileEdgeLength)), GetNumTiles() - IntVector2::ONE);
+    const float tileEdgeLength = tileSize_ * cellSize_;
+    return VectorFloorToInt(position.ToXZ() / tileEdgeLength);
 }
 
-void NavigationMesh::RemoveTile(const IntVector2& tile)
+void NavigationMesh::RemoveTile(const IntVector2& tileIndex)
 {
     if (!navMesh_)
         return;
 
-    const dtTileRef tileRef = navMesh_->getTileRefAt(tile.x_, tile.y_, 0);
+    const dtTileRef tileRef = navMesh_->getTileRefAt(tileIndex.x_, tileIndex.y_, 0);
     if (!tileRef)
         return;
 
@@ -553,7 +515,7 @@ void NavigationMesh::RemoveTile(const IntVector2& tile)
     VariantMap& eventData = GetContext()->GetEventDataMap();
     eventData[P_NODE] = GetNode();
     eventData[P_MESH] = this;
-    eventData[P_TILE] = tile;
+    eventData[P_TILE] = tileIndex;
     SendEvent(E_NAVIGATION_TILE_REMOVED, eventData);
 }
 
@@ -836,11 +798,6 @@ void NavigationMesh::SetAreaCost(unsigned areaID, float cost)
         queryFilter_->setAreaCost((int)areaID, cost);
 }
 
-BoundingBox NavigationMesh::GetWorldBoundingBox() const
-{
-    return node_ ? boundingBox_.Transformed(node_->GetWorldTransform()) : boundingBox_;
-}
-
 float NavigationMesh::GetAreaCost(unsigned areaID) const
 {
     if (queryFilter_)
@@ -857,12 +814,19 @@ void NavigationMesh::SetNavigationDataAttr(const ea::vector<unsigned char>& valu
 
     MemoryBuffer buffer(value);
 
-    boundingBox_ = buffer.ReadBoundingBox();
-    numTilesX_ = buffer.ReadInt();
-    numTilesZ_ = buffer.ReadInt();
+    // Keep the header the same as the old data format to check for validity.
+    buffer.ReadBoundingBox();
+    const int unused0 = buffer.ReadInt();
+    const int unused1 = buffer.ReadInt();
+    const int version = buffer.ReadInt();
+    if (unused0 != 0 || unused1 != 0 || version != NavigationDataVersion)
+    {
+        URHO3D_LOGWARNING("Incompatible navigation data format, please rebuild navigation data");
+        return;
+    }
 
-    dtNavMeshParams params;     // NOLINT(hicpp-member-init)
-    rcVcopy(params.orig, &boundingBox_.min_.x_);
+    dtNavMeshParams params{};     // NOLINT(hicpp-member-init)
+    // TODO: Fill params.orig
     params.tileWidth = buffer.ReadFloat();
     params.tileHeight = buffer.ReadFloat();
     params.maxTiles = buffer.ReadInt();
@@ -892,7 +856,7 @@ void NavigationMesh::SetNavigationDataAttr(const ea::vector<unsigned char>& valu
             return;
     }
 
-    URHO3D_LOGDEBUG("Created navigation mesh with " + ea::to_string(numTiles) + " tiles from serialized data");
+    URHO3D_LOGDEBUG("Created navigation mesh with {} tiles from serialized data", numTiles);
     // \todo Shall we send E_NAVIGATION_MESH_REBUILT here?
 }
 
@@ -902,9 +866,10 @@ ea::vector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
 
     if (navMesh_)
     {
-        ret.WriteBoundingBox(boundingBox_);
-        ret.WriteInt(numTilesX_);
-        ret.WriteInt(numTilesZ_);
+        ret.WriteBoundingBox(BoundingBox{});
+        ret.WriteInt(0);
+        ret.WriteInt(0);
+        ret.WriteInt(NavigationDataVersion);
 
         const dtNavMeshParams* params = navMesh_->getParams();
         ret.WriteFloat(params->tileWidth);
@@ -912,11 +877,14 @@ ea::vector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
         ret.WriteInt(params->maxTiles);
         ret.WriteInt(params->maxPolys);
 
-        const dtNavMesh* navMesh = navMesh_;
+        for (int i = 0; i < navMesh_->getMaxTiles(); ++i)
+        {
+            const dtMeshTile* tile = const_cast<const dtNavMesh*>(navMesh_)->getTile(i);
+            if (!tile || !tile->header || !tile->dataSize)
+                continue;
 
-        for (int z = 0; z < numTilesZ_; ++z)
-            for (int x = 0; x < numTilesX_; ++x)
-                WriteTile(ret, x, z);
+            WriteTile(ret, tile);
+        }
     }
 
     return ret.GetBuffer();
@@ -1222,25 +1190,10 @@ void NavigationMesh::AddTriMeshGeometry(NavBuildData* build, Geometry* geometry,
     }
 }
 
-void NavigationMesh::WriteTile(Serializer& dest, int x, int z) const
-{
-    const dtNavMesh* navMesh = navMesh_;
-    const dtMeshTile* tile = navMesh->getTileAt(x, z, 0);
-    if (!tile)
-        return;
-
-    dest.WriteInt(x);
-    dest.WriteInt(z);
-    dest.WriteUInt(navMesh->getTileRef(tile));
-    dest.WriteUInt((unsigned)tile->dataSize);
-    dest.Write(tile->data, (unsigned)tile->dataSize);
-}
-
 bool NavigationMesh::ReadTile(Deserializer& source, bool silent)
 {
     const int x = source.ReadInt();
     const int z = source.ReadInt();
-    /*dtTileRef tileRef =*/ source.ReadUInt();
     unsigned navDataSize = source.ReadUInt();
 
     auto* navData = (unsigned char*)dtAlloc(navDataSize, DT_ALLOC_PERM);
@@ -1258,17 +1211,20 @@ bool NavigationMesh::ReadTile(Deserializer& source, bool silent)
         return false;
     }
 
-    // Send event
     if (!silent)
-    {
-        using namespace NavigationTileAdded;
-        VariantMap& eventData = GetContext()->GetEventDataMap();
-        eventData[P_NODE] = GetNode();
-        eventData[P_MESH] = this;
-        eventData[P_TILE] = IntVector2(x, z);
-        SendEvent(E_NAVIGATION_TILE_ADDED, eventData);
-    }
+        SendTileAddedEvent(IntVector2(x, z));
+
     return true;
+}
+
+void NavigationMesh::SendTileAddedEvent(const IntVector2& tileIndex)
+{
+    using namespace NavigationTileAdded;
+    VariantMap& eventData = GetContext()->GetEventDataMap();
+    eventData[P_NODE] = GetNode();
+    eventData[P_MESH] = this;
+    eventData[P_TILE] = tileIndex;
+    SendEvent(E_NAVIGATION_TILE_ADDED, eventData);
 }
 
 bool NavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometryList, int x, int z)
@@ -1278,12 +1234,13 @@ bool NavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometryList,
     // Remove previous tile (if any)
     navMesh_->removeTile(navMesh_->getTileRefAt(x, z, 0), nullptr, nullptr);
 
-    const BoundingBox tileBoundingBox = GetTileBoundingBox(IntVector2(x, z));
+    const BoundingBox tileColumn = GetTileBoundingBoxColumn(IntVector2{x, z});
+    const BoundingBox tileBoundingBox = CalculateTileBoundingBox(geometryList, tileColumn);
 
     SimpleNavBuildData build;
 
     rcConfig cfg;       // NOLINT(hicpp-member-init)
-    memset(&cfg, 0, sizeof cfg);
+    memset(&cfg, 0, sizeof(cfg));
     cfg.cs = cellSize_;
     cfg.ch = cellHeight_;
     cfg.walkableSlopeAngle = agentMaxSlope_;
@@ -1305,8 +1262,10 @@ bool NavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometryList,
     rcVcopy(cfg.bmin, &tileBoundingBox.min_.x_);
     rcVcopy(cfg.bmax, &tileBoundingBox.max_.x_);
     cfg.bmin[0] -= cfg.borderSize * cfg.cs;
+    cfg.bmin[1] -= padding_.y_;
     cfg.bmin[2] -= cfg.borderSize * cfg.cs;
     cfg.bmax[0] += cfg.borderSize * cfg.cs;
+    cfg.bmax[1] += padding_.y_;
     cfg.bmax[2] += cfg.borderSize * cfg.cs;
 
     BoundingBox expandedBox(*reinterpret_cast<Vector3*>(cfg.bmin), *reinterpret_cast<Vector3*>(cfg.bmax));
@@ -1499,7 +1458,8 @@ bool NavigationMesh::BuildTile(ea::vector<NavigationGeometryInfo>& geometryList,
     return true;
 }
 
-unsigned NavigationMesh::BuildTiles(ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to)
+unsigned NavigationMesh::BuildTilesFromGeometry(
+    ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to)
 {
     unsigned numTiles = 0;
 
@@ -1545,10 +1505,6 @@ void NavigationMesh::ReleaseNavigationMesh()
 
     dtFreeNavMeshQuery(navMeshQuery_);
     navMeshQuery_ = nullptr;
-
-    numTilesX_ = 0;
-    numTilesZ_ = 0;
-    boundingBox_.Clear();
 }
 
 void NavigationMesh::SetPartitionType(NavmeshPartitionType partitionType)

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -105,6 +105,8 @@ public:
     /// Set cell height.
     /// @property
     void SetCellHeight(float height);
+    /// Set min and max height of the navigation mesh, i.e. min and max Y value in world space.
+    void SetHeightRange(const Vector2& range) { heightRange_ = range; }
     /// Set navigation agent height.
     /// @property
     void SetAgentHeight(float height);
@@ -216,6 +218,12 @@ public:
     /// Return cell height.
     /// @property
     float GetCellHeight() const { return cellHeight_; }
+
+    /// Return min and max height of the navigation mesh, i.e. min and max Y value in world space.
+    const Vector2& GetHeightRange() const { return heightRange_; }
+
+    /// Return whether the height range is valid.
+    bool IsHeightRangeValid() const { return heightRange_.x_ < heightRange_.y_; }
 
     /// Return navigation agent height.
     /// @property
@@ -347,6 +355,8 @@ protected:
     float cellSize_;
     /// Cell height.
     float cellHeight_;
+    /// Total height range of the navigation mesh, in world space.
+    Vector2 heightRange_;
     /// Navigation agent height.
     float agentHeight_;
     /// Navigation agent radius.

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -24,18 +24,12 @@
 
 #pragma once
 
+#include "Urho3D/Math/BoundingBox.h"
+#include "Urho3D/Navigation/NavigationDefs.h"
+#include "Urho3D/Scene/Component.h"
+
 #include <EASTL/unique_ptr.h>
 #include <EASTL/unordered_set.h>
-
-#include "../Math/BoundingBox.h"
-#include "../Math/Matrix3x4.h"
-#include "../Scene/Component.h"
-
-#ifdef DT_POLYREF64
-using dtPolyRef = uint64_t;
-#else
-using dtPolyRef = unsigned int;
-#endif
 
 class dtNavMesh;
 class dtNavMeshQuery;
@@ -55,20 +49,7 @@ class NavArea;
 
 struct FindPathData;
 struct NavBuildData;
-
-/// Description of a navigation mesh geometry component, with transform and bounds information.
-struct NavigationGeometryInfo
-{
-    /// Component.
-    Component* component_;
-    /// Geometry LOD level if applicable.
-    unsigned lodLevel_;
-    /// Transform relative to the navigation mesh root node.
-    Matrix3x4 transform_;
-    /// Bounding box relative to the navigation mesh root node.
-    BoundingBox boundingBox_;
-
-};
+struct NavigationGeometryInfo;
 
 /// A flag representing the type of path point- none, the start of a path segment, the end of one, or an off-mesh connection.
 enum NavigationPathPointFlag
@@ -97,6 +78,11 @@ class URHO3D_API NavigationMesh : public Component
     friend class CrowdManager;
 
 public:
+    /// Version of compiled navigation data. Navigation data should be discarded and rebuilt on mismatch.
+    static constexpr int NavigationDataVersion = 1;
+    /// Default maximum number of tiles.
+    static constexpr int DefaultMaxTiles = 256;
+
     /// Construct.
     explicit NavigationMesh(Context* context);
     /// Destruct.
@@ -108,6 +94,8 @@ public:
     /// Visualize the component as debug geometry.
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
+    /// Set maximum number of tiles.
+    void SetMaxTiles(int maxTiles) { maxTiles_ = Max(maxTiles, 1); }
     /// Set tile size.
     /// @property
     void SetTileSize(int size);
@@ -152,26 +140,30 @@ public:
     void SetPadding(const Vector3& padding);
     /// Set the cost of an area.
     void SetAreaCost(unsigned areaID, float cost);
-    /// Allocate the navigation mesh without building any tiles. Bounding box is not padded. Return true if successful.
-    virtual bool Allocate(const BoundingBox& boundingBox, unsigned maxTiles);
-    /// Rebuild the navigation mesh. Return true if successful.
-    virtual bool Build();
+
+    /// Allocate the navigation mesh without building any tiles. Return true if successful.
+    bool Allocate();
     /// Rebuild part of the navigation mesh contained by the world-space bounding box. Return true if successful.
-    virtual bool Build(const BoundingBox& boundingBox);
+    bool BuildTilesInRegion(const BoundingBox& boundingBox);
     /// Rebuild part of the navigation mesh in the rectangular area. Return true if successful.
-    virtual bool Build(const IntVector2& from, const IntVector2& to);
+    bool BuildTiles(const IntVector2& from, const IntVector2& to);
+    /// Rebuild the navigation mesh allocating sufficient maximum number of tiles. Return true if successful.
+    bool Rebuild();
+
+    /// Enumerate all tiles.
+    ea::vector<IntVector2> GetAllTileIndices() const;
     /// Return tile data.
-    virtual ea::vector<unsigned char> GetTileData(const IntVector2& tile) const;
+    virtual ea::vector<unsigned char> GetTileData(const IntVector2& tileIndex) const;
     /// Add tile to navigation mesh.
     virtual bool AddTile(const ea::vector<unsigned char>& tileData);
     /// Remove tile from navigation mesh.
-    virtual void RemoveTile(const IntVector2& tile);
+    virtual void RemoveTile(const IntVector2& tileIndex);
     /// Remove all tiles from navigation mesh.
     virtual void RemoveAllTiles();
     /// Return whether the navigation mesh has tile.
-    bool HasTile(const IntVector2& tile) const;
-    /// Return bounding box of the tile in the node space.
-    BoundingBox GetTileBoundingBox(const IntVector2& tile) const;
+    bool HasTile(const IntVector2& tileIndex) const;
+    /// Return bounding box of the tile in the world space. Y coordinate spans from -infinity to infinity.
+    BoundingBox GetTileBoundingBoxColumn(const IntVector2& tileIndex) const;
     /// Return index of the tile at the position.
     IntVector2 GetTileIndex(const Vector3& position) const;
     /// Find the nearest point on the navigation mesh to a given point. Extents specifies how far out from the specified point to check along each axis.
@@ -209,6 +201,9 @@ public:
 
     /// Set the name of this navigation mesh.
     void SetMeshName(const ea::string& newName);
+
+    /// Return maximum number of tiles.
+    int GetMaxTiles() const { return maxTiles_; }
 
     /// Return tile size.
     /// @property
@@ -273,18 +268,6 @@ public:
     /// @property
     bool IsInitialized() const { return navMesh_ != nullptr; }
 
-    /// Return local space bounding box of the navigation mesh.
-    /// @property
-    const BoundingBox& GetBoundingBox() const { return boundingBox_; }
-
-    /// Return world space bounding box of the navigation mesh.
-    /// @property
-    BoundingBox GetWorldBoundingBox() const;
-
-    /// Return number of tiles.
-    /// @property
-    IntVector2 GetNumTiles() const { return IntVector2(numTilesX_, numTilesZ_); }
-
     /// Set the partition type used for polygon generation.
     /// @property
     void SetPartitionType(NavmeshPartitionType partitionType);
@@ -315,12 +298,22 @@ public:
     bool GetDrawNavAreas() const { return drawNavAreas_; }
 
 private:
-    /// Write tile data.
-    void WriteTile(Serializer& dest, int x, int z) const;
     /// Read tile data to the navigation mesh.
     bool ReadTile(Deserializer& source, bool silent);
 
 protected:
+    /// Allocate the navigation mesh without building any tiles. Return true if successful.
+    virtual bool AllocateMesh(unsigned maxTiles);
+    /// Rebuild the navigation mesh allocating sufficient maximum number of tiles. Return true if successful.
+    virtual bool RebuildMesh();
+    /// Build mesh tiles from the geometry data. Return true if successful.
+    virtual unsigned BuildTilesFromGeometry(
+        ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to);
+
+    /// Send rebuild event.
+    void SendRebuildEvent();
+    /// Send tile added event.
+    void SendTileAddedEvent(const IntVector2& tileIndex);
     /// Collect geometry from under Navigable components.
     void CollectGeometries(ea::vector<NavigationGeometryInfo>& geometryList);
     /// Visit nodes and collect navigable geometry.
@@ -330,9 +323,7 @@ protected:
     /// Add a triangle mesh to the geometry data.
     void AddTriMeshGeometry(NavBuildData* build, Geometry* geometry, const Matrix3x4& transform);
     /// Build one tile of the navigation mesh. Return true if successful.
-    virtual bool BuildTile(ea::vector<NavigationGeometryInfo>& geometryList, int x, int z);
-    /// Build tiles in the rectangular area. Return number of built tiles.
-    unsigned BuildTiles(ea::vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to);
+    bool BuildTile(ea::vector<NavigationGeometryInfo>& geometryList, int x, int z);
     /// Ensure that the navigation mesh query is initialized. Return true if successful.
     bool InitializeQuery();
     /// Release the navigation mesh and the query.
@@ -348,6 +339,8 @@ protected:
     ea::unique_ptr<dtQueryFilter> queryFilter_;
     /// Temporary data for finding a path.
     ea::unique_ptr<FindPathData> pathData_;
+    /// Maximum number of tiles.
+    int maxTiles_{DefaultMaxTiles};
     /// Tile size.
     int tileSize_;
     /// Cell size.
@@ -376,12 +369,6 @@ protected:
     float detailSampleMaxError_;
     /// Bounding box padding.
     Vector3 padding_;
-    /// Number of tiles in X direction.
-    int numTilesX_;
-    /// Number of tiles in Z direction.
-    int numTilesZ_;
-    /// Whole navigation mesh bounding box.
-    BoundingBox boundingBox_;
     /// Type of the heightfield partitioning.
     NavmeshPartitionType partitionType_;
     /// Keep internal build resources for debug draw modes.

--- a/Source/Urho3D/Navigation/NavigationUtils.cpp
+++ b/Source/Urho3D/Navigation/NavigationUtils.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+#include "Urho3D/Precompiled.h"
+
+#include "Urho3D/Navigation/NavigationUtils.h"
+
+namespace Urho3D
+{
+
+BoundingBox CalculateBoundingBox(const ea::vector<NavigationGeometryInfo>& geometryList, const Vector3& padding)
+{
+    BoundingBox result;
+    for (unsigned i = 0; i < geometryList.size(); ++i)
+        result.Merge(geometryList[i].boundingBox_);
+
+    result.min_ -= padding;
+    result.max_ += padding;
+
+    return result;
+}
+
+BoundingBox CalculateTileBoundingBox(
+    const ea::vector<NavigationGeometryInfo>& geometryList, const BoundingBox& tileColumn)
+{
+    BoundingBox result = tileColumn;
+    result.min_.y_ = M_LARGE_VALUE;
+    result.max_.y_ = -M_LARGE_VALUE;
+
+    for (const NavigationGeometryInfo& info : geometryList)
+    {
+        if (info.boundingBox_.IsInside(tileColumn) == OUTSIDE)
+            continue;
+
+        result.min_.y_ = ea::min(result.min_.y_, info.boundingBox_.min_.y_);
+        result.max_.y_ = ea::max(result.max_.y_, info.boundingBox_.max_.y_);
+    }
+
+    // Repair empty bounding box
+    if (result.max_.y_ < result.min_.y_)
+    {
+        result.min_.y_ = 0.0f;
+        result.max_.y_ = 0.0f;
+    }
+
+    return result;
+}
+
+unsigned CalculateMaxTiles(const BoundingBox& boundingBox, int tileSize, float cellSize)
+{
+    if (!boundingBox.Defined())
+        return 0;
+
+    const float tileEdgeLength = tileSize * cellSize;
+    const IntVector2 beginTileIndex = VectorFloorToInt(boundingBox.min_.ToXZ() / tileEdgeLength);
+    const IntVector2 endTileIndex = VectorFloorToInt(boundingBox.max_.ToXZ() / tileEdgeLength);
+    const IntVector2 numTiles = endTileIndex - beginTileIndex + IntVector2::ONE;
+
+    return NextPowerOfTwo(static_cast<unsigned>(numTiles.x_ * numTiles.y_));
+}
+
+} // namespace Urho3D

--- a/Source/Urho3D/Navigation/NavigationUtils.h
+++ b/Source/Urho3D/Navigation/NavigationUtils.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+#pragma once
+
+#include "Urho3D/Math/BoundingBox.h"
+#include "Urho3D/Math/Matrix3x4.h"
+
+#include <vector>
+
+namespace Urho3D
+{
+
+class Component;
+
+/// Description of a navigation mesh geometry component, with transform and bounds information.
+struct NavigationGeometryInfo
+{
+    /// Component.
+    Component* component_{};
+    /// Geometry LOD level if applicable.
+    unsigned lodLevel_{};
+    /// Transform relative to the navigation mesh root node.
+    Matrix3x4 transform_;
+    /// Bounding box relative to the navigation mesh root node.
+    BoundingBox boundingBox_;
+};
+
+/// Calculate bounding box of given geometry.
+URHO3D_API BoundingBox CalculateBoundingBox(
+    const ea::vector<NavigationGeometryInfo>& geometryList, const Vector3& padding);
+
+/// Calculate bounding box of given geometry within the given tile volume.
+URHO3D_API BoundingBox CalculateTileBoundingBox(
+    const ea::vector<NavigationGeometryInfo>& geometryList, const BoundingBox& tileColumn);
+
+/// Calculate maximum number of tiles required to contain the given bounding box.
+URHO3D_API unsigned CalculateMaxTiles(const BoundingBox& boundingBox, int tileSize, float cellSize);
+
+} // namespace Urho3D


### PR DESCRIPTION
Fixed-size `(Dynamic)NavigationMesh` should behave almost the same as before.

However, it's not required to know the total dimenstions of the navigation mesh anymore. It can be partially built on demand as long as maximum number of loaded tiles is below the threshold.

This way, it's possible to use navigation system for arbitrarily large worlds. User will have to deal with building, loading and unloading parts of navigation mesh, of course. `Navigation` and `CrowdNavigation` samples may serve as example.

Full list of changes:

- Navigation data format has changed, all previously stored navigation data should be discarded and meshes re-baked. There should be no crashes when loading old data tho.
- Some function renames: `Rebuild` rebuilds entire navigation mesh and deduces maximum number of chunks required to store entire mesh. `Allocate` allocates empty navigation mesh with previously set capacity (Max Tiles attribute). `BuildTilesInRegion` and `BuildTiles` functions are used to build mesh tiles corresponding to the specified part of the Scene.
- Navigation meshes no longer care about the total `BoundingBox` of navigable geometry, only about the number of simultaneously loaded tiles.
- Fixed unreliable Obstacle placement. It may be slower now, but at least it is guaranteed to work. Future optimizations are possible.
- Fixed silent failure when navigation mesh tile building allocates more than 32kb of memory.