### PR TITLE
Copy material attributes

### DIFF
--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -869,6 +869,28 @@ SharedPtr<Material> Material::Clone(const ea::string& cloneName) const
     return ret;
 }
 
+void Material::CopyFrom(const Material* material)
+{
+    this->SetName(material->GetName());
+    techniques_ = material->techniques_;
+    vertexShaderDefines_ = material->vertexShaderDefines_;
+    pixelShaderDefines_ = material->pixelShaderDefines_;
+    shaderParameters_ = material->shaderParameters_;
+    shaderParameterHash_ = material->shaderParameterHash_;
+    textures_ = material->textures_;
+    depthBias_ = material->depthBias_;
+    alphaToCoverage_ = material->alphaToCoverage_;
+    lineAntiAlias_ = material->lineAntiAlias_;
+    occlusion_ = material->occlusion_;
+    specular_ = material->specular_;
+    cullMode_ = material->cullMode_;
+    shadowCullMode_ = material->shadowCullMode_;
+    fillMode_ = material->fillMode_;
+    renderOrder_ = material->renderOrder_;
+    RefreshMemoryUse();
+    RefreshTextureEventSubscriptions();
+}
+
 void Material::SortTechniques()
 {
     ea::sort(techniques_.begin(), techniques_.end());

--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -846,26 +846,8 @@ void Material::ReleaseShaders()
 SharedPtr<Material> Material::Clone(const ea::string& cloneName) const
 {
     SharedPtr<Material> ret(MakeShared<Material>(context_));
-
+    ret->CopyFrom(this);
     ret->SetName(cloneName);
-    ret->techniques_ = techniques_;
-    ret->vertexShaderDefines_ = vertexShaderDefines_;
-    ret->pixelShaderDefines_ = pixelShaderDefines_;
-    ret->shaderParameters_ = shaderParameters_;
-    ret->shaderParameterHash_ = shaderParameterHash_;
-    ret->textures_ = textures_;
-    ret->depthBias_ = depthBias_;
-    ret->alphaToCoverage_ = alphaToCoverage_;
-    ret->lineAntiAlias_ = lineAntiAlias_;
-    ret->occlusion_ = occlusion_;
-    ret->specular_ = specular_;
-    ret->cullMode_ = cullMode_;
-    ret->shadowCullMode_ = shadowCullMode_;
-    ret->fillMode_ = fillMode_;
-    ret->renderOrder_ = renderOrder_;
-    ret->RefreshMemoryUse();
-    ret->RefreshTextureEventSubscriptions();
-
     return ret;
 }
 

--- a/Source/Urho3D/Graphics/Material.h
+++ b/Source/Urho3D/Graphics/Material.h
@@ -220,6 +220,8 @@ public:
     void ReleaseShaders();
     /// Clone the material.
     SharedPtr<Material> Clone(const ea::string& cloneName = EMPTY_STRING) const;
+    /// Copy another material. This is useful for a pool of Material objects.
+    void CopyFrom(const Material* material);
     /// Ensure that material techniques are listed in correct order.
     void SortTechniques();
     /// Mark material for auxiliary view rendering.


### PR DESCRIPTION
Copy operation is required for material pool. Material pool is required while we don't have per-drawable shader parameters and have to use a copy of material to animate properties independently.

@eugeneko any plans on adding per-drawable shader parameters?