### PR TITLE
Fixed MoveAndOrbitController not being able to set custom input maps.

### DIFF
--- a/Source/Urho3D/Input/MoveAndOrbitController.cpp
+++ b/Source/Urho3D/Input/MoveAndOrbitController.cpp
@@ -64,7 +64,7 @@ void MoveAndOrbitController::OnSetEnabled()
 
 void MoveAndOrbitController::LoadInputMap(const ea::string& name)
 {
-    SetInputMapAttr(ResourceRef(InputMap::GetTypeStatic(), "Input/MoveAndOrbit.inputmap"));
+    SetInputMapAttr(ResourceRef(InputMap::GetTypeStatic(), name));
 }
 
 void MoveAndOrbitController::SetInputMap(InputMap* inputMap)


### PR DESCRIPTION
The MoveAndOrbitController has it hard-coded to the default input map file.