### PR TITLE
Added more on screen info to scene replication sample

### DIFF
--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -512,16 +512,14 @@ void SceneReplication::HandlePostUpdate(StringHash eventType, VariantMap& eventD
 
     if (auto* connectionToServer = network->GetServerConnection())
     {
-        SampleConnection(connectionToServer, packetsIn, packetsOut, bytesIn, bytesOut);
         connectionCount = 1;
+        SampleConnection(connectionToServer, packetsIn, packetsOut, bytesIn, bytesOut);
     }
     else
     {
+        connectionCount = network->GetClientConnections().size();
         for (const auto& connection : network->GetClientConnections())
-        {
-            ++connectionCount;
             SampleConnection(connection, packetsIn, packetsOut, bytesIn, bytesOut);
-        }
     }
 
     UpdateOverlay(packetsIn, packetsOut, bytesIn, bytesOut, connectionCount);

--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -67,6 +67,12 @@ static const unsigned CTRL_BACK = 2;
 static const unsigned CTRL_LEFT = 4;
 static const unsigned CTRL_RIGHT = 8;
 
+static const ea::string PACKETS_IN_TITLE    = "Packets  in";
+static const ea::string PACKETS_OUT_TITLE   = "Packets out";
+static const ea::string BYTES_IN_TITLE      = "Bytes    in";
+static const ea::string BYTES_OUT_TITLE     = "Bytes   out";
+static const ea::string CONNECTIONS_TITLE   = "Connections";
+
 /// Controls data.
 struct PlayerControls
 {
@@ -270,19 +276,17 @@ void SceneReplication::CreateUI()
     // Hide until connected
     instructionsText_->SetVisible(false);
 
-    packetsIn_ = GetUIRoot()->CreateChild<Text>();
-    packetsIn_->SetText("Packets in : 0");
-    packetsIn_->SetFont(cache->GetResource<Font>("Fonts/Anonymous Pro.ttf"), 15);
-    packetsIn_->SetHorizontalAlignment(HA_LEFT);
-    packetsIn_->SetVerticalAlignment(VA_CENTER);
-    packetsIn_->SetPosition(10, -10);
+    int y = -10;
 
-    packetsOut_ = GetUIRoot()->CreateChild<Text>();
-    packetsOut_->SetText("Packets out: 0");
-    packetsOut_->SetFont(cache->GetResource<Font>("Fonts/Anonymous Pro.ttf"), 15);
-    packetsOut_->SetHorizontalAlignment(HA_LEFT);
-    packetsOut_->SetVerticalAlignment(VA_CENTER);
-    packetsOut_->SetPosition(10, 10);
+    packetsIn_ = CreateOverlayText(y);
+    packetsOut_ = CreateOverlayText(y);
+    bytesIn_ = CreateOverlayText(y);
+    bytesOut_ = CreateOverlayText(y);
+    connections_ = CreateOverlayText(y);
+    serverRunning_ = CreateOverlayText(y);
+
+    const int defaultValue = 0;
+    UpdateOverlay(defaultValue, defaultValue, defaultValue, defaultValue, defaultValue);
 
     buttonContainer_ = root->CreateChild<UIElement>();
     buttonContainer_->SetFixedSize(500, 20);
@@ -444,30 +448,87 @@ void SceneReplication::MoveCamera()
     instructionsText_->SetVisible(showInstructions);
 }
 
+Text* SceneReplication::CreateOverlayText(int& y)
+{
+    const int x = 10;
+    const int yOffset = 20;
+    const auto fontSize = 15;
+
+    auto* cache = GetSubsystem<ResourceCache>();
+    auto font = cache->GetResource<Font>("Fonts/Anonymous Pro.ttf");
+
+    auto textElement = GetUIRoot()->CreateChild<Text>();
+    textElement->SetFont(font, fontSize);
+    textElement->SetHorizontalAlignment(HA_LEFT);
+    textElement->SetVerticalAlignment(VA_CENTER);
+    textElement->SetPosition(x, y += yOffset);
+
+    return textElement;
+}
+
+void SetOverlayText(SharedPtr<Text>& textElement, const ea::string& title, int value)
+{
+    textElement->SetText(Format("{}: {}", title, value));
+}
+
+void SceneReplication::UpdateOverlay(int packetsIn, int packetsOut, int bytesIn, int bytesOut, int connections)
+{
+    SetOverlayText(packetsIn_, PACKETS_IN_TITLE, packetsIn);
+    SetOverlayText(packetsOut_, PACKETS_OUT_TITLE, packetsOut);
+    SetOverlayText(bytesIn_, BYTES_IN_TITLE, bytesIn);
+    SetOverlayText(bytesOut_, BYTES_OUT_TITLE, bytesOut);
+    SetOverlayText(connections_, CONNECTIONS_TITLE, connections);
+    const auto* network = GetSubsystem<Network>();
+    serverRunning_->SetText(network->IsServerRunning() ? "Server on" : "");
+}
+
+void SampleConnection(const Connection* connection, int& packetsIn, int& packetsOut, int& bytesIn, int& bytesOut)
+{
+    packetsIn += connection->GetPacketsInPerSec();
+    packetsOut += connection->GetPacketsOutPerSec();
+    bytesIn += connection->GetBytesInPerSec();
+    bytesOut += connection->GetBytesOutPerSec();
+}
+
 void SceneReplication::HandlePostUpdate(StringHash eventType, VariantMap& eventData)
 {
     // We only rotate the camera according to mouse movement since last frame, so do not need the time step
     MoveCamera();
 
-    if (packetCounterTimer_.GetMSec(false) > 1000 && GetSubsystem<Network>()->GetServerConnection())
+    if (packetCounterTimer_.GetMSec(false) < 1000)
     {
-        packetsIn_->SetText("Packets  in: " + ea::to_string(GetSubsystem<Network>()->GetServerConnection()->GetPacketsInPerSec()));
-        packetsOut_->SetText("Packets out: " + ea::to_string(GetSubsystem<Network>()->GetServerConnection()->GetPacketsOutPerSec()));
-        packetCounterTimer_.Reset();
+        return;
     }
-    if (packetCounterTimer_.GetMSec(false) > 1000 && GetSubsystem<Network>()->GetClientConnections().size())
+
+    packetCounterTimer_.Reset();
+
+    const auto* network = GetSubsystem<Network>();
+
+    int packetsIn = 0;
+    int packetsOut = 0;
+    int bytesIn = 0;
+    int bytesOut = 0;
+    int connectionCount = 0;
+
+    if (auto* connectionToServer = network->GetServerConnection())
     {
-        int packetsIn = 0;
-        int packetsOut = 0;
-        auto connections = GetSubsystem<Network>()->GetClientConnections();
-        for (auto it = connections.begin(); it != connections.end(); ++it ) {
-            packetsIn += (*it)->GetPacketsInPerSec();
-            packetsOut += (*it)->GetPacketsOutPerSec();
+        SampleConnection(connectionToServer, packetsIn, packetsOut, bytesIn, bytesOut);
+        connectionCount = 1;
+    }
+    else
+    {
+        const auto connectionsToClients = network->GetClientConnections();
+        if (!connectionsToClients.empty())
+        {
+            connectionCount = connectionsToClients.size();
+            for (int i = 0; i < connectionCount; ++i)
+            {
+                SampleConnection(connectionsToClients[i], packetsIn, packetsOut, bytesIn, bytesOut);
+            }
         }
-        packetsIn_->SetText("Packets  in: " + ea::to_string(packetsIn));
-        packetsOut_->SetText("Packets out: " + ea::to_string(packetsOut));
-        packetCounterTimer_.Reset();
     }
+
+    UpdateOverlay(packetsIn, packetsOut, bytesIn, bytesOut, connectionCount);
 }
 
 void SceneReplication::HandlePhysicsPreStep(StringHash eventType, VariantMap& eventData)

--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -466,12 +466,12 @@ Text* SceneReplication::CreateOverlayText(int& y)
     return textElement;
 }
 
-void SetOverlayText(SharedPtr<Text>& textElement, const ea::string& title, int value)
+void SetOverlayText(SharedPtr<Text>& textElement, const ea::string& title, unsigned value)
 {
     textElement->SetText(Format("{}: {}", title, value));
 }
 
-void SceneReplication::UpdateOverlay(int packetsIn, int packetsOut, int bytesIn, int bytesOut, int connections)
+void SceneReplication::UpdateOverlay(unsigned packetsIn, unsigned packetsOut, unsigned bytesIn, unsigned bytesOut, unsigned connections)
 {
     SetOverlayText(packetsIn_, PACKETS_IN_TITLE, packetsIn);
     SetOverlayText(packetsOut_, PACKETS_OUT_TITLE, packetsOut);
@@ -482,7 +482,7 @@ void SceneReplication::UpdateOverlay(int packetsIn, int packetsOut, int bytesIn,
     serverRunning_->SetText(network->IsServerRunning() ? "Server on" : "");
 }
 
-void SampleConnection(const Connection* connection, int& packetsIn, int& packetsOut, int& bytesIn, int& bytesOut)
+void SampleConnection(const Connection* connection, unsigned& packetsIn, unsigned& packetsOut, unsigned& bytesIn, unsigned& bytesOut)
 {
     packetsIn += connection->GetPacketsInPerSec();
     packetsOut += connection->GetPacketsOutPerSec();
@@ -504,11 +504,11 @@ void SceneReplication::HandlePostUpdate(StringHash eventType, VariantMap& eventD
 
     const auto* network = GetSubsystem<Network>();
 
-    int packetsIn = 0;
-    int packetsOut = 0;
-    int bytesIn = 0;
-    int bytesOut = 0;
-    int connectionCount = 0;
+    unsigned packetsIn = 0;
+    unsigned packetsOut = 0;
+    unsigned bytesIn = 0;
+    unsigned bytesOut = 0;
+    unsigned connectionCount = 0;
 
     if (auto* connectionToServer = network->GetServerConnection())
     {
@@ -521,7 +521,7 @@ void SceneReplication::HandlePostUpdate(StringHash eventType, VariantMap& eventD
         if (!connectionsToClients.empty())
         {
             connectionCount = connectionsToClients.size();
-            for (int i = 0; i < connectionCount; ++i)
+            for (unsigned i = 0; i < connectionCount; ++i)
             {
                 SampleConnection(connectionsToClients[i], packetsIn, packetsOut, bytesIn, bytesOut);
             }

--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -517,14 +517,10 @@ void SceneReplication::HandlePostUpdate(StringHash eventType, VariantMap& eventD
     }
     else
     {
-        const auto connectionsToClients = network->GetClientConnections();
-        if (!connectionsToClients.empty())
+        for (const auto& connection : network->GetClientConnections())
         {
-            connectionCount = connectionsToClients.size();
-            for (unsigned i = 0; i < connectionCount; ++i)
-            {
-                SampleConnection(connectionsToClients[i], packetsIn, packetsOut, bytesIn, bytesOut);
-            }
+            ++connectionCount;
+            SampleConnection(connection, packetsIn, packetsOut, bytesIn, bytesOut);
         }
     }
 

--- a/Source/Samples/17_SceneReplication/SceneReplication.h
+++ b/Source/Samples/17_SceneReplication/SceneReplication.h
@@ -74,7 +74,7 @@ private:
     /// Create a text from the UI root.
     Text* CreateOverlayText(int& y);
     /// Update all the values on the info overlay.
-    void UpdateOverlay(int packetsIn, int packetsOut, int bytesIn, int bytesOut, int connections);
+    void UpdateOverlay(unsigned packetsIn, unsigned packetsOut, unsigned bytesIn, unsigned bytesOut, unsigned connections);
     /// Create a button to the button container.
     Button* CreateButton(const ea::string& text, int width);
     /// Update visibility of buttons according to connection and server status.

--- a/Source/Samples/17_SceneReplication/SceneReplication.h
+++ b/Source/Samples/17_SceneReplication/SceneReplication.h
@@ -71,6 +71,10 @@ private:
     void SetupViewport();
     /// Subscribe to update, UI and network events.
     void SubscribeToEvents();
+    /// Create a text from the UI root.
+    Text* CreateOverlayText(int& y);
+    /// Update all the values on the info overlay.
+    void UpdateOverlay(int packetsIn, int packetsOut, int bytesIn, int bytesOut, int connections);
     /// Create a button to the button container.
     Button* CreateButton(const ea::string& text, int width);
     /// Update visibility of buttons according to connection and server status.
@@ -118,6 +122,14 @@ private:
     SharedPtr<Text> packetsIn_;
     /// Packets out per second
     SharedPtr<Text> packetsOut_;
+    /// Bytes in per second
+    SharedPtr<Text> bytesIn_;
+    /// Bytes out per second
+    SharedPtr<Text> bytesOut_;
+    /// Number of connections
+    SharedPtr<Text> connections_;
+    /// IsServerRunning status
+    SharedPtr<Text> serverRunning_;
     /// Packet counter UI update timer
     Timer packetCounterTimer_;
 };


### PR DESCRIPTION
The change also updates the overlay to default/0 values when disconnected, before it would keep showing the last set values.

![image](https://github.com/rbfx/rbfx/assets/171250488/d7f10b62-5f92-45be-b9df-e725edade311)
