### PR TITLE
Use cached TypeId from static method to resovle types

### DIFF
--- a/Source/Tests/CSharp/Scene/Node.cs
+++ b/Source/Tests/CSharp/Scene/Node.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Urho3DNet.Tests
+{
+    public class NodeTests
+    {
+        [Fact]
+        public async Task GetDerivedComponent_ByExactType()
+        {
+            await RbfxTestFramework.Context.ToMainThreadAsync();
+
+            var node = RbfxTestFramework.Context.CreateObject<Node>();
+            var component = node.CreateComponent<DerivedFromTestComponent>();
+
+            Assert.Equal(component, node.GetDerivedComponent<DerivedFromTestComponent>());
+        }
+
+        [Fact]
+        public async Task GetDerivedComponent_ByBaseType()
+        {
+            await RbfxTestFramework.Context.ToMainThreadAsync();
+
+            var node = RbfxTestFramework.Context.CreateObject<Node>();
+            var component = node.CreateComponent<DerivedFromTestComponent>();
+
+            Assert.Equal(component, node.GetDerivedComponent<Component>());
+        }
+
+        [Fact]
+        public async Task GetDerivedComponent_ByInterface()
+        {
+            await RbfxTestFramework.Context.ToMainThreadAsync();
+
+            var node = RbfxTestFramework.Context.CreateObject<Node>();
+            var component = node.CreateComponent<DerivedFromTestComponent>();
+
+            Assert.Equal(component, (DerivedFromTestComponent)node.GetDerivedComponent<IDerivedFromTestComponent>());
+        }
+    }
+
+    [DerivedFrom]
+    public interface IDerivedFromTestComponent
+    {
+    }
+
+    [ObjectFactory]
+    public partial class DerivedFromTestComponent : Component, IDerivedFromTestComponent
+    {
+        public DerivedFromTestComponent(IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        public DerivedFromTestComponent(Context context) : base(context)
+        {
+        }
+    }
+}

--- a/Source/Urho3D/CSharp/CodeGenerator/CodeGenerator.cs
+++ b/Source/Urho3D/CSharp/CodeGenerator/CodeGenerator.cs
@@ -22,6 +22,8 @@ namespace Urho3DNet
                 return;
             }
 
+            INamedTypeSymbol? derivedFromAttribute = compilation.GetTypeByMetadataName("Urho3DNet.DerivedFromAttribute");
+
             var visitedClasses = new HashSet<string>();
 
             foreach (var syntaxTree in compilation.SyntaxTrees)
@@ -74,8 +76,9 @@ namespace Urho3DNet
 
                         nestedInClasses.Reverse();
 
-                        foreach (var namedTypeSymbol in nestedInClasses)
+                        for (var index = 0; index < nestedInClasses.Count; index++)
                         {
+                            var namedTypeSymbol = nestedInClasses[index];
                             sourceBuilder.AppendLine($"partial class {GetClassNameWithoutNamespace(namedTypeSymbol)} {{");
                         }
 
@@ -87,6 +90,7 @@ namespace Urho3DNet
 
                         var hasClassName = HasStaticField(typeSymbolInfo, "ClassName");
 
+                        sourceBuilder.AppendLine("[global::Urho3DNet.Preserve(AllMembers=true)]");
                         sourceBuilder.AppendLine($"partial class {className} {{");
 
                         bool hasGetTypeName = false;
@@ -131,7 +135,9 @@ namespace Urho3DNet
                             sourceBuilder.AppendLine($"    public static new readonly StringHash TypeId = new StringHash(ClassName);");
 
                         sourceBuilder.Append($"    public static new readonly StringHash[] TypeHierarchy = new []{{");
-                        sourceBuilder.Append(string.Join(", ", typeHierarchy.Select(_ => $"{_}.TypeId")));
+
+                        var typesAndInterfaces = typeHierarchy.Concat(CollectInterfaces(typeSymbolInfo, derivedFromAttribute)).Distinct(SymbolEqualityComparer.Default);
+                        sourceBuilder.Append(string.Join(", ", typesAndInterfaces.Select(_ => $"global::Urho3DNet.ObjectReflection<{_}>.TypeId")));
                         sourceBuilder.AppendLine("};");
 
 
@@ -226,6 +232,27 @@ namespace Urho3DNet
             }
 
             return  false;
+        }
+
+        private IEnumerable<ITypeSymbol> CollectInterfaces(ITypeSymbol? namedType, INamedTypeSymbol? interfaceAttribute)
+        {
+            if (namedType == null)
+                yield break;
+
+            if (interfaceAttribute == null)
+                yield break;
+
+            foreach (var implementedInterface in namedType.AllInterfaces)
+            {
+                foreach (var attr in implementedInterface.GetAttributes())
+                {
+                    if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, interfaceAttribute))
+                    {
+                        yield return implementedInterface;
+                        break;
+                    }
+                }
+            }
         }
 
         public static bool TryGetParentSyntax<T>(SyntaxNode? syntaxNode, out T? result) where T : SyntaxNode

--- a/Source/Urho3D/CSharp/Managed/Core/Object.cs
+++ b/Source/Urho3D/CSharp/Managed/Core/Object.cs
@@ -80,7 +80,7 @@ namespace Urho3DNet
 
         public T GetSubsystem<T>() where T : Object
         {
-            return (T)GetSubsystem(typeof(T).Name);
+            return (T)GetSubsystem(ObjectReflection<T>.TypeId);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Managed/Core/ObjectReflection.cs
+++ b/Source/Urho3D/CSharp/Managed/Core/ObjectReflection.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+using System;
+using System.Reflection;
+
+namespace Urho3DNet
+{
+    /// <summary>
+    /// Object reflection type that caches type information for a given type.
+    /// </summary>
+    public static class ObjectReflection<T>
+    {
+        public static string ClassName { get; }
+
+        public static StringHash TypeId { get; }
+
+        static ObjectReflection()
+        {
+            var type = typeof(T);
+            var getTypeNameStatic = type.GetMethod(nameof(Urho3DNet.Object.GetTypeNameStatic), BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (getTypeNameStatic != null)
+            {
+                ClassName = (string)getTypeNameStatic.Invoke(null, Array.Empty<object>());
+            }
+            else
+            {
+                ClassName = type.Name;
+            }
+
+            var getTypeStatic = type.GetMethod(nameof(Urho3DNet.Object.GetTypeStatic), BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (getTypeStatic != null)
+            {
+                TypeId = (StringHash)getTypeStatic.Invoke(null, Array.Empty<object>());
+            }
+            else
+            {
+                TypeId = ClassName;
+            }
+        }
+    }
+}

--- a/Source/Urho3D/CSharp/Managed/DerivedFromAttribute.cs
+++ b/Source/Urho3D/CSharp/Managed/DerivedFromAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2024-2024 the rbfx project.
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT> or the accompanying LICENSE file.
+
+namespace Urho3DNet
+{
+    /// <summary>
+    /// Add interface to the list of base types to allow <see cref="Node.GetDerivedComponent{T}"/> find component by the interface.
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Interface)]
+    public sealed class DerivedFromAttribute : System.Attribute
+    {
+    }
+}

--- a/Source/Urho3D/CSharp/Managed/Resource/ResourceCache.cs
+++ b/Source/Urho3D/CSharp/Managed/Resource/ResourceCache.cs
@@ -26,12 +26,12 @@ namespace Urho3DNet
     {
         public T GetResource<T>(string name, bool sendEventOnFailure = true) where T: Resource
         {
-            return (T) GetResource(typeof(T).Name, name, sendEventOnFailure);
+            return (T) GetResource(ObjectReflection<T>.TypeId, name, sendEventOnFailure);
         }
 
         public T GetTempResource<T>(string name, bool sendEventOnFailure = true) where T : Resource
         {
-            return (T)GetTempResource(typeof(T).Name, name, sendEventOnFailure);
+            return (T)GetTempResource(ObjectReflection<T>.TypeId, name, sendEventOnFailure);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Managed/Scene/Component.cs
+++ b/Source/Urho3D/CSharp/Managed/Scene/Component.cs
@@ -26,7 +26,7 @@ namespace Urho3DNet
     {
         public T GetComponent<T>() where T : Component
         {
-            return (T)GetComponent(typeof(T).Name);
+            return (T)GetComponent(ObjectReflection<T>.TypeId);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Managed/Scene/Node.cs
+++ b/Source/Urho3D/CSharp/Managed/Scene/Node.cs
@@ -28,22 +28,22 @@ namespace Urho3DNet
     {
         public T CreateComponent<T>(uint id = 0) where T: Component
         {
-            return (T)CreateComponent(typeof(T).Name, id);
+            return (T)CreateComponent(ObjectReflection<T>.TypeId, id);
         }
 
         public T GetComponent<T>(bool recursive) where T: Component
         {
-            return (T)GetComponent(typeof(T).Name, recursive);
+            return (T)GetComponent(ObjectReflection<T>.TypeId, recursive);
         }
 
         public T GetOrCreateComponent<T>(uint id = 0) where T: Component
         {
-            return (T)GetOrCreateComponent(typeof(T).Name, id);
+            return (T)GetOrCreateComponent(ObjectReflection<T>.TypeId, id);
         }
 
         public void RemoveComponent<T>() where T : Component
         {
-            RemoveComponent(typeof(T).Name);
+            RemoveComponent(ObjectReflection<T>.TypeId);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Urho3DNet
         /// <returns>Found component or null.</returns>
         public T GetComponent<T>() where T: Component
         {
-            return (T)GetComponent(typeof(T).Name);
+            return (T)GetComponent(ObjectReflection<T>.TypeId);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Urho3DNet
         public ComponentList GetComponents<T>(bool recursive = false) where T: Component
         {
             ComponentList componentList = new ComponentList();
-            GetComponents(componentList, typeof(T).Name, recursive);
+            GetComponents(componentList, ObjectReflection<T>.TypeId, recursive);
             return componentList;
         }
 
@@ -75,28 +75,28 @@ namespace Urho3DNet
         /// <returns>Found component or null.</returns>
         public T GetParentComponent<T>(bool fullTraversal = false) where T : Component
         {
-            return (T)GetParentComponent(typeof(T).Name, fullTraversal);
+            return (T)GetParentComponent(ObjectReflection<T>.TypeId, fullTraversal);
         }
 
         /// <summary>
         /// Get first occurrence of a component derived from the type.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">Type inherited from <see cref="Urho3DNet.Component"/> or interface marked with <see cref="Urho3DNet.DerivedFromAttribute"/></typeparam>
         /// <returns>Found component or null.</returns>
-        public T GetDerivedComponent<T>() where T : Component
+        public T GetDerivedComponent<T>() where T: class
         {
-            return (T)GetDerivedComponent(typeof(T).Name);
+            return GetDerivedComponent(ObjectReflection<T>.TypeId) as T;
         }
 
         /// <summary>
         /// Get all components that derives from type.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">Type inherited from <see cref="Urho3DNet.Component"/> or interface marked with <see cref="Urho3DNet.DerivedFromAttribute"/></typeparam>
         /// <returns>List of found components.</returns>
-        public ComponentList GetDerivedComponents<T>(bool recursive = false) where T : Component
+        public ComponentList GetDerivedComponents<T>(bool recursive = false)
         {
             ComponentList componentList = new ComponentList();
-            GetDerivedComponents(componentList, typeof(T).Name, recursive);
+            GetDerivedComponents(componentList, ObjectReflection<T>.TypeId, recursive);
             return componentList;
         }
 
@@ -107,7 +107,7 @@ namespace Urho3DNet
         /// <returns>Found component or null.</returns>
         public T GetParentDerivedComponent<T>(bool fullTraversal = false) where T : Component
         {
-            return (T)GetParentDerivedComponent(typeof(T).Name, fullTraversal);
+            return (T)GetParentDerivedComponent(ObjectReflection<T>.TypeId, fullTraversal);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Managed/UI/UIElement.cs
+++ b/Source/Urho3D/CSharp/Managed/UI/UIElement.cs
@@ -29,22 +29,22 @@ namespace Urho3DNet
     {
         public T CreateChild<T>() where T : UIElement
         {
-            return (T)CreateChild(typeof(T).Name);
+            return (T)CreateChild(ObjectReflection<T>.TypeId);
         }
 
         public T CreateChild<T>(string name) where T : UIElement
         {
-            return (T)CreateChild(typeof(T).Name, name);
+            return (T)CreateChild(ObjectReflection<T>.TypeId, name);
         }
 
         public T CreateChild<T>(string name, uint index) where T : UIElement
         {
-            return (T)CreateChild(typeof(T).Name, name, index);
+            return (T)CreateChild(ObjectReflection<T>.TypeId, name, index);
         }
 
         public T GetChild<T>(string name, bool recursive) where T : UIElement
         {
-            return (T) GetChild(typeof(T).Name, name, recursive);
+            return (T) GetChild(ObjectReflection<T>.TypeId, name, recursive);
         }
     }
 }

--- a/Source/Urho3D/CSharp/Swig/Urho3D.i
+++ b/Source/Urho3D/CSharp/Swig/Urho3D.i
@@ -91,7 +91,7 @@ using namespace Urho3D;
 // Speed boost
 %pragma(csharp) imclassclassmodifiers="[System.Security.SuppressUnmanagedCodeSecurity]\npublic unsafe class"
 %pragma(csharp) moduleclassmodifiers="[System.Security.SuppressUnmanagedCodeSecurity]\npublic unsafe partial class"
-%typemap(csclassmodifiers) SWIGTYPE "[global::Urho3DNet.Preserve(AllMembers=true)]\npublic unsafe partial class"
+%typemap(csclassmodifiers) SWIGTYPE "public unsafe partial class"
 
 %{
 #if _WIN32


### PR DESCRIPTION
New ObjectReflection<T> stores a cached value of TypeId from GetStaticType() method. This allows non-trivial naming for the types (for example type names that include namespace on c++ side).

Attribute [DerivedFrom] includes interfaces into type search. This is useful for components that implement multiple interfaces in c#.

[Preserve] attribute automatically injected into all c# Urho3DNet Object classes to ensure Scene deserialization even if game code is compiled ahead-of-time (iOS/Web).