### PR TITLE
Added HttpRequest::GetStatusCode()

### DIFF
--- a/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
+++ b/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
@@ -102,13 +102,15 @@ void HttpRequestDemo::Update(float timeStep)
         {
             text_->SetText("An error has occurred: " + httpRequest_->GetError());
             UnsubscribeFromEvent(E_UPDATE);
-            URHO3D_LOGERRORF("HttpRequest error: %s", httpRequest_->GetError().c_str());
+            URHO3D_LOGERRORF("HttpRequest error: %s (%d)", httpRequest_->GetError().c_str(), httpRequest_->GetStatusCode());
         }
         else if (httpRequest_->GetState() == Urho3D::HTTP_OPEN)
             text_->SetText("Processing...");
         else if (httpRequest_->GetState() == Urho3D::HTTP_CLOSED)
         {
             message_ = httpRequest_->ReadString();
+
+            URHO3D_LOGINFOF("HttpRequest success: %s (%d)", message_.c_str(), httpRequest_->GetStatusCode());
 
             SharedPtr<JSONFile> json(new JSONFile(context_));
             json->FromString(message_);

--- a/Source/Urho3D/Network/HttpRequest.cpp
+++ b/Source/Urho3D/Network/HttpRequest.cpp
@@ -97,8 +97,11 @@ HttpRequest::HttpRequest(
         HttpRequest* request = static_cast<HttpRequest*>(fetch->userData);
         MutexLock lock(request->mutex_);
         request->state_ = HTTP_CLOSED;
-        request->readBuffer_.Resize(fetch->numBytes - 1);
-        request->readBuffer_.SetData(fetch->data, fetch->numBytes - 1);
+        if (fetch->numBytes > 0)
+        {
+            request->readBuffer_.Resize(fetch->numBytes - 1);
+            request->readBuffer_.SetData(fetch->data, fetch->numBytes - 1);
+        }
         request->requestHandle_ = nullptr;
         request->statusCode_ = fetch->status;
 

--- a/Source/Urho3D/Network/HttpRequest.cpp
+++ b/Source/Urho3D/Network/HttpRequest.cpp
@@ -114,8 +114,12 @@ HttpRequest::HttpRequest(
 
         HttpRequest* request = static_cast<HttpRequest*>(fetch->userData);
         MutexLock lock(request->mutex_);
-        request->state_ = HTTP_ERROR;
-        request->error_ = fetch->statusText;
+        const bool error = fetch->status == 0;
+        request->state_ = error ? HTTP_ERROR : HTTP_CLOSED;
+        if (error)
+        {
+            request->error_ = fetch->statusText;
+        }
         request->requestHandle_ = nullptr;
         request->statusCode_ = fetch->status;
 

--- a/Source/Urho3D/Network/HttpRequest.h
+++ b/Source/Urho3D/Network/HttpRequest.h
@@ -87,6 +87,10 @@ public:
     /// @property
     bool IsOpen() const { return GetState() == HTTP_OPEN; }
 
+    /// Return HTTP response status code eg. 200(OK) or 404(NOT_FOUND).
+    /// @property
+    int GetStatusCode() const;
+
 private:
     /// URL.
     URL url_;
@@ -106,6 +110,8 @@ private:
     VectorBuffer readBuffer_;
     /// Read buffer read cursor.
     unsigned readPosition_ = 0;
+    /// HTTP response status code eg. 200(OK) or 404(NOT_FOUND)
+    int statusCode_ = 0;
 #ifdef URHO3D_PLATFORM_WEB
     /// HTTP request handle.
     void* requestHandle_ = nullptr;

--- a/Source/Urho3D/Network/HttpRequest.h
+++ b/Source/Urho3D/Network/HttpRequest.h
@@ -87,8 +87,7 @@ public:
     /// @property
     bool IsOpen() const { return GetState() == HTTP_OPEN; }
 
-    /// Return HTTP response status code eg. 200(OK) or 404(NOT_FOUND).
-    /// @property
+    /// Return HTTP response status code, e.g. 200(OK) or 404(NOT_FOUND).
     int GetStatusCode() const;
 
 private:
@@ -110,7 +109,7 @@ private:
     VectorBuffer readBuffer_;
     /// Read buffer read cursor.
     unsigned readPosition_ = 0;
-    /// HTTP response status code eg. 200(OK) or 404(NOT_FOUND)
+    /// HTTP response status code, e.g. 200(OK) or 404(NOT_FOUND).
     int statusCode_ = 0;
 #ifdef URHO3D_PLATFORM_WEB
     /// HTTP request handle.


### PR DESCRIPTION
Added this because I needed it, any projects using http likely would too e.g. handling specific api error codes, avoiding re-downloading cached content with code 304 etc.