### PR TITLE
Added MoveAndOrbit components to a category

### DIFF
--- a/Source/Urho3D/Input/MoveAndOrbitComponent.cpp
+++ b/Source/Urho3D/Input/MoveAndOrbitComponent.cpp
@@ -34,7 +34,7 @@ MoveAndOrbitComponent::MoveAndOrbitComponent(Context* context)
 
 void MoveAndOrbitComponent::RegisterObject(Context* context)
 {
-    context->AddFactoryReflection<MoveAndOrbitComponent>();
+    context->AddFactoryReflection<MoveAndOrbitComponent>(Category_Logic);
 }
 
 void MoveAndOrbitComponent::SetVelocity(const Vector3& velocity)

--- a/Source/Urho3D/Input/MoveAndOrbitController.cpp
+++ b/Source/Urho3D/Input/MoveAndOrbitController.cpp
@@ -47,7 +47,7 @@ MoveAndOrbitController::~MoveAndOrbitController()
 
 void MoveAndOrbitController::RegisterObject(Context* context)
 {
-    context->AddFactoryReflection<MoveAndOrbitController>();
+    context->AddFactoryReflection<MoveAndOrbitController>(Category_Logic);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE(
         "Input Map", GetInputMapAttr, SetInputMapAttr, ResourceRef, ResourceRef(InputMap::GetTypeStatic()), AM_DEFAULT);
 }


### PR DESCRIPTION
These components don't show up in the editor component creation context menu if they don't belong to a category. I just picked the logic category since they are LogicComponents, maybe there is a better fit.