### PR TITLE
Default arg of Timer::Get_Sec() now defaults to false since it's the common case

### DIFF
--- a/Source/Urho3D/Core/Timer.h
+++ b/Source/Urho3D/Core/Timer.h
@@ -37,7 +37,7 @@ public:
     Timer();
 
     /// Return elapsed milliseconds and optionally reset.
-    unsigned GetMSec(bool reset);
+    unsigned GetMSec(bool reset = false);
     /// Reset the timer.
     void Reset();
 
@@ -56,7 +56,7 @@ public:
     HiresTimer();
 
     /// Return elapsed microseconds and optionally reset.
-    long long GetUSec(bool reset);
+    long long GetUSec(bool reset = false);
     /// Reset the timer.
     void Reset();
 


### PR DESCRIPTION
![Screenshot 2024-11-24 at 9 21 29 PM](https://github.com/user-attachments/assets/6db001a2-fb5c-4a30-8f1a-382181734b77)
