### PR TITLE
Fix for RmlUIComponent::SetResource() re-entry crash in editor

### DIFF
--- a/Source/ThirdParty/RmlUi/Source/Core/Context.cpp
+++ b/Source/ThirdParty/RmlUi/Source/Core/Context.cpp
@@ -893,7 +893,7 @@ DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegist
 		return DataModelConstructor(result.first->second.get());
 
 	Log::Message(Log::LT_ERROR, "Data model name '%s' already exists.", name.c_str());
-	return DataModelConstructor();
+	return GetDataModel(name);
 }
 
 DataModelConstructor Context::GetDataModel(const String& name)


### PR DESCRIPTION
In the editor, If a scene has an `RmlUIComponent` in it, the second time it is loaded in play mode it will crash when binding because its `DataModelConstructor` has already been created. Returning the pre-existing `DataModelConstructor` solves this.