### PR TITLE
Removed Network::MakeHttpRequest()

### DIFF
--- a/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
+++ b/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
@@ -23,7 +23,6 @@
 #include <Urho3D/Core/CoreEvents.h>
 #include <Urho3D/Core/ProcessUtils.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/Network/Network.h>
 #include <Urho3D/Network/HttpRequest.h>
 #include <Urho3D/UI/Font.h>
 #include <Urho3D/UI/Text.h>
@@ -80,16 +79,14 @@ void HttpRequestDemo::SubscribeToEvents()
 
 void HttpRequestDemo::Update(float timeStep)
 {
-    auto* network = GetSubsystem<Network>();
-
     if (httpRequest_ == nullptr)
     {
         const ea::string verb = "GET";
         const ea::vector<ea::string> headers = {"hello: world"};
 #ifdef URHO3D_SSL
-        httpRequest_ = network->MakeHttpRequest("https://api.ipify.org/?format=json", verb, headers);
+        httpRequest_ = MakeShared<HttpRequest>("https://api.ipify.org/?format=json", verb, headers);
 #else
-        httpRequest_ = network->MakeHttpRequest("http://httpbin.org/ip", verb, headers);
+        httpRequest_ = MakeShared<HttpRequest>("http://httpbin.org/ip", verb, headers);
 #endif
     }
     else

--- a/Source/Urho3D/Network/HttpRequest.cpp
+++ b/Source/Urho3D/Network/HttpRequest.cpp
@@ -77,6 +77,8 @@ HttpRequest::HttpRequest(
     , headers_(headers)
     , postData_(postData)
 {
+    URHO3D_PROFILE("HttpRequest()");
+
     // Size of response is unknown, so just set maximum value. The position will also be changed
     // to maximum value once the request is done, signaling end for Deserializer::IsEof().
     size_ = M_MAX_UNSIGNED;

--- a/Source/Urho3D/Network/HttpRequest.cpp
+++ b/Source/Urho3D/Network/HttpRequest.cpp
@@ -77,7 +77,7 @@ HttpRequest::HttpRequest(
     , headers_(headers)
     , postData_(postData)
 {
-    URHO3D_PROFILE("HttpRequest()");
+    URHO3D_PROFILE("HttpRequest");
 
     // Size of response is unknown, so just set maximum value. The position will also be changed
     // to maximum value once the request is done, signaling end for Deserializer::IsEof().

--- a/Source/Urho3D/Network/HttpRequest.h
+++ b/Source/Urho3D/Network/HttpRequest.h
@@ -46,11 +46,13 @@ enum HttpRequestState
 };
 
 /// An HTTP connection with response data stream.
+/// Perform an HTTP request to the specified URL. Empty verb defaults to a GET request. Return a request object which
+/// can be used to read the response data.
 class URHO3D_API HttpRequest : public RefCounted, public Deserializer, public Thread
 {
 public:
     /// Construct with parameters.
-    HttpRequest(const ea::string& url, const ea::string& verb, const ea::vector<ea::string>& headers, const ea::string& postData);
+    HttpRequest(const ea::string& url, const ea::string& verb = EMPTY_STRING, const ea::vector<ea::string>& headers = ea::vector<ea::string>(), const ea::string& postData = EMPTY_STRING);
     /// Destruct. Release the connection object.
     ~HttpRequest() override;
 

--- a/Source/Urho3D/Network/Network.cpp
+++ b/Source/Urho3D/Network/Network.cpp
@@ -379,16 +379,6 @@ void Network::SendPackageToClients(Scene* scene, PackageFile* package)
     }
 }
 
-SharedPtr<HttpRequest> Network::MakeHttpRequest(const ea::string& url, const ea::string& verb, const ea::vector<ea::string>& headers,
-    const ea::string& postData)
-{
-    URHO3D_PROFILE("MakeHttpRequest");
-
-    // The initialization of the request will take time, can not know at this point if it has an error or not
-    SharedPtr<HttpRequest> request(new HttpRequest(url, verb, headers, postData));
-    return request;
-}
-
 Connection* Network::GetServerConnection() const
 {
     return connectionToServer_;

--- a/Source/Urho3D/Network/Network.h
+++ b/Source/Urho3D/Network/Network.h
@@ -86,8 +86,6 @@ public:
     void SetPackageCacheDir(const ea::string& path);
     /// Trigger all client connections in the specified scene to download a package file from the server. Can be used to download additional resource packages when clients are already joined in the scene. The package must have been added as a requirement to the scene, or else the eventual download will fail.
     void SendPackageToClients(Scene* scene, PackageFile* package);
-    /// Perform an HTTP request to the specified URL. Empty verb defaults to a GET request. Return a request object which can be used to read the response data.
-    SharedPtr<HttpRequest> MakeHttpRequest(const ea::string& url, const ea::string& verb = EMPTY_STRING, const ea::vector<ea::string>& headers = ea::vector<ea::string>(), const ea::string& postData = EMPTY_STRING);
     /// Return network update FPS.
     /// @property
     unsigned GetUpdateFps() const { return updateFps_; }


### PR DESCRIPTION
The `Network` subsystem and `HttpRequest` should be de-coupled so that projects can opt in/out of using either one if they need to.

This PR doesn't achieve this but it's the first step towards doing it. I have already decoupled these in my fork since I have a project that uses http but not `Network/Replica`.

I'll wait for feedback before proceeding with the rest.