### PR TITLE
Fix editor dockspace tabs missing

### DIFF
--- a/Source/Editor/EditorApplication.cpp
+++ b/Source/Editor/EditorApplication.cpp
@@ -349,11 +349,13 @@ void EditorApplication::Render()
         : 0.0f;
     const float toolbarEffectiveHeight = toolbarHeight + 1;
 
+    const float menuBarHeight = g.FontSize + g.Style.FramePadding.y * 2.0f; 
+
     ImGuiWindowFlags flags = ImGuiWindowFlags_MenuBar;
     flags |= ImGuiWindowFlags_NoDocking;
     ImGuiViewport* viewport = ui::GetMainViewport();
-    ui::SetNextWindowPos(viewport->Pos + ImVec2(0, toolbarEffectiveHeight));
-    ui::SetNextWindowSize(viewport->Size - ImVec2(0, toolbarEffectiveHeight));
+    ui::SetNextWindowPos(viewport->Pos + ImVec2(0, toolbarEffectiveHeight + menuBarHeight));
+    ui::SetNextWindowSize(viewport->Size - ImVec2(0, toolbarEffectiveHeight + menuBarHeight));
     ui::SetNextWindowViewport(viewport->ID);
     ui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
     flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
@@ -418,8 +420,6 @@ void EditorApplication::Render()
         ui::EndGroup();
         ui::PopStyleVar();
     }
-
-    const float menuBarHeight = ui::GetCurrentWindow()->MenuBarHeight;
 
     ui::End();
     ui::PopStyleVar();


### PR DESCRIPTION
Update to calculate menu bar height sooner. (Same logic as IMGUI uses internally) and use it to offset the dockspace, such that it doesn't overlap with toolbar.
Before:
![Screenshot from 2025-04-30 23-09-41](https://github.com/user-attachments/assets/364a5e73-2d11-4db6-960c-8364e5a4c369)
After:
![Screenshot from 2025-04-30 23-10-19](https://github.com/user-attachments/assets/aae0589e-c364-468a-bbd9-9d3e549e339a)
