### PR TITLE
work well under MacOS with Silicon Arm CPU.

### DIFF
--- a/CMake/Modules/UrhoOptions.cmake
+++ b/CMake/Modules/UrhoOptions.cmake
@@ -128,7 +128,7 @@ else ()
     set (URHO3D_PCH OFF)
 endif ()
 
-if (UWP)
+if (UWP OR (APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"))
     set (URHO3D_SSE OFF)
 else ()
     set (URHO3D_SSE           SSE2 CACHE STRING "Enable SSE instructions")

--- a/Source/ThirdParty/FreeType/src/gzip/ftzconf.h
+++ b/Source/ThirdParty/FreeType/src/gzip/ftzconf.h
@@ -217,6 +217,8 @@
 
 #if !defined(MACOS) && !defined(TARGET_OS_MAC)
 typedef unsigned char  Byte;  /* 8 bits */
+#else
+#include <MacTypes.h>
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */
 typedef unsigned long  uLong; /* 32 bits or more */


### PR DESCRIPTION
- update embree to 3.13.5, and fix this: https://github.com/RenderKit/embree/commit/cda4cf191

- URHO3D_SSE OFF under MacOS Silicon.

- #include <MacTypes.h> in FreeType/src/gzip/ftzconf.h under MacOS Silicon.