### PR TITLE
Minor fixes

### DIFF
--- a/Source/Editor/CMakeLists.txt
+++ b/Source/Editor/CMakeLists.txt
@@ -27,6 +27,43 @@ endif ()
 file (GLOB_RECURSE SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp *.h *.hpp)
 list (REMOVE_ITEM SOURCE_FILES Editor.cpp EditorWrapper.cpp)
 
+#
+# Groups sources so that they're displayed in IDE matching their layout in the filesystem
+#
+file (GLOB CoreFiles ${CMAKE_CURRENT_SOURCE_DIR} Core/*.*)
+source_group(Core FILES ${CoreFiles})
+
+file (GLOB ProjectFiles ${CMAKE_CURRENT_SOURCE_DIR} Project/*.*)
+source_group(Project FILES ${ProjectFiles})
+
+file(GLOB Foundation ${CMAKE_CURRENT_SOURCE_DIR} Foundation/*.*)
+source_group(Foundation FILES ${Foundation})
+
+file(GLOB Glue ${CMAKE_CURRENT_SOURCE_DIR} Foundation/Glue/*.*)
+source_group(Foundation/Glue FILES ${Glue})
+
+file(GLOB InspectorTab ${CMAKE_CURRENT_SOURCE_DIR} Foundation/InspectorTab/*.*)
+source_group(Foundation/InspectorTab FILES ${InspectorTab})
+
+file(GLOB ResourceBrowserTab ${CMAKE_CURRENT_SOURCE_DIR} Foundation/ResourceBrowserTab/*.*)
+source_group(Foundation/ResourceBrowserTab FILES ${ResourceBrowserTab})
+
+file(GLOB SceneViewTab ${CMAKE_CURRENT_SOURCE_DIR} Foundation/SceneViewTab/*.*)
+source_group(Foundation/SceneViewTab FILES ${SceneViewTab})
+
+file(GLOB SettingsTab ${CMAKE_CURRENT_SOURCE_DIR} Foundation/SettingsTab/*.*)
+source_group(Foundation/SettingsTab FILES ${SettingsTab})
+
+file(GLOB Shared ${CMAKE_CURRENT_SOURCE_DIR} Foundation/Shared/*.*)
+source_group(Foundation/Shared FILES ${Shared})
+
+file(GLOB Assets ${CMAKE_CURRENT_SOURCE_DIR} Assets/*.*)
+source_group(Assets FILES ${Assets})
+
+
+file (GLOB sourceFiles ${CMAKE_CURRENT_SOURCE_DIR} *.cpp *.h *.hpp)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${sourceFiles})
+
 # Always export Editor without entry point as EditorLibrary.
 # TODO: Support SHARED EditorLibrary for external Editor plugins.
 add_library (EditorLibrary STATIC ${SOURCE_FILES})

--- a/Source/Urho3D/Audio/SoundSource.cpp
+++ b/Source/Urho3D/Audio/SoundSource.cpp
@@ -436,7 +436,7 @@ void SoundSource::Mix(int dest[], unsigned samples, int mixRate, SpeakerMode mod
                 break;
             case SPK_SURROUND_5_1:
                 if (lowFrequency_)
-                    MixMonoToMonoIP(sound, dest, samples, mixRate, SOUND_SOURCE_LOW_FREQ_CHANNEL[mode], 6);
+                    MixMonoToMonoIP(sound, dest, samples, mixRate, effectiveFrequency, SOUND_SOURCE_LOW_FREQ_CHANNEL[mode], 6);
                 else
                     MixMonoToSurroundIP(sound, dest, samples, mixRate, effectiveFrequency, mode);
                 break;

--- a/Source/Urho3D/Core/Spline.cpp
+++ b/Source/Urho3D/Core/Spline.cpp
@@ -81,14 +81,14 @@ Variant Spline::GetPoint(float f) const
                 if (knots_.front() != knots_.back())
                 {
                     fullKnots.push_back(knots_.front());
-                    fullKnots.push_back(knots_);
+                    fullKnots.insert(fullKnots.end(), knots_.begin(), knots_.end());
                     fullKnots.push_back(knots_.back());
                 }
                 // Cyclic case: smooth the tangents
                 else
                 {
                     fullKnots.push_back(knots_[knots_.size() - 2]);
-                    fullKnots.push_back(knots_);
+                    fullKnots.insert(fullKnots.end(), knots_.begin(), knots_.end());
                     fullKnots.push_back(knots_[1]);
                 }
             }

--- a/Source/Urho3D/SystemUI/SystemUI.cpp
+++ b/Source/Urho3D/SystemUI/SystemUI.cpp
@@ -138,21 +138,46 @@ void SystemUI::OnRawEvent(VariantMap& args)
         relativeMouseMove_.y_ += evt->motion.yrel;
         break;
     case SDL_FINGERUP:
+    {
         io.AddMouseSourceEvent(ImGuiMouseSource_TouchScreen);
-        io.AddMousePosEvent(-1, -1);
         io.AddMouseButtonEvent(0, false);
-        break;
+        io.AddMousePosEvent(-1, -1);
+    }
+    break;
     case SDL_FINGERDOWN:
+    {
         io.AddMouseSourceEvent(ImGuiMouseSource_TouchScreen);
+        ImVec2 mouse_pos((float)evt->tfinger.x, (float)evt->tfinger.y);
+        // TODO: is this condition actually relevant, looks not?
+        if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+        {
+            int window_x, window_y;
+            int size_x, size_y;
+            auto win = SDL_GetWindowFromID(evt->tfinger.windowID);
+            SDL_GetWindowPosition(win, &window_x, &window_y);
+            SDL_GetWindowSize(win, &size_x, &size_y);
+            mouse_pos.x *= size_x;
+            mouse_pos.y *= size_y;
+            mouse_pos.x += window_x;
+            mouse_pos.y += window_y;
+        }
+        io.AddMousePosEvent(mouse_pos.x, mouse_pos.y);
         io.AddMouseButtonEvent(0, true);
-        break;
+        io.AddMousePosEvent(mouse_pos.x, mouse_pos.y);
+    }
+    break;
     case SDL_FINGERMOTION:
     {
         ImVec2 mouse_pos((float)evt->tfinger.x, (float)evt->tfinger.y);
         if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
         {
             int window_x, window_y;
-            SDL_GetWindowPosition(SDL_GetWindowFromID(evt->tfinger.windowID), &window_x, &window_y);
+            int size_x, size_y;
+            auto win = SDL_GetWindowFromID(evt->tfinger.windowID);
+            SDL_GetWindowPosition(win, &window_x, &window_y);
+            SDL_GetWindowSize(win, &size_x, &size_y);
+            mouse_pos.x *= size_x;
+            mouse_pos.y *= size_y;
             mouse_pos.x += window_x;
             mouse_pos.y += window_y;
         }


### PR DESCRIPTION
Collection of minor fixes. Catmull rom one is a bit of doozy, no idea how long that was there. The problem was probably with the old Urho containers behaving differently, allowing appending a vector by elements. Then EA::STL vectors and implicit conversion to Variant makes a problem subtle problem.

Point of CMake change is to make EditorLibrary less daunting to look at and figure out where stuff is vs filesystem and IDE.