### PR TITLE
Precalculate and cache cubemap spherical harmonics to avoid repeated image reads.

### DIFF
--- a/Source/Urho3D/Graphics/TextureCube.cpp
+++ b/Source/Urho3D/Graphics/TextureCube.cpp
@@ -75,6 +75,8 @@ void TextureCube::RegisterObject(Context* context)
 
 bool TextureCube::BeginLoad(Deserializer& source)
 {
+    sphericalHarmonics_.reset();
+
     auto* cache = GetSubsystem<ResourceCache>();
     auto graphics = GetSubsystem<Graphics>();
 
@@ -88,6 +90,9 @@ bool TextureCube::BeginLoad(Deserializer& source)
     loadImageCube_ = cache->GetTempResource<ImageCube>(GetName());
     if (!loadImageCube_)
         return false;
+
+    // ImageCube might have precalculated spherical harmonics. Copy them, because ImageCube eventually gets deleted.
+    sphericalHarmonics_ = loadImageCube_->GetSphericalHarmonics();
 
     // Update dependencies
     for (Image* image : loadImageCube_->GetImages())

--- a/Source/Urho3D/Graphics/TextureCube.cpp
+++ b/Source/Urho3D/Graphics/TextureCube.cpp
@@ -75,8 +75,6 @@ void TextureCube::RegisterObject(Context* context)
 
 bool TextureCube::BeginLoad(Deserializer& source)
 {
-    sphericalHarmonics_.reset();
-
     auto* cache = GetSubsystem<ResourceCache>();
     auto graphics = GetSubsystem<Graphics>();
 
@@ -91,7 +89,6 @@ bool TextureCube::BeginLoad(Deserializer& source)
     if (!loadImageCube_)
         return false;
 
-    // ImageCube might have precalculated spherical harmonics. Copy them, because ImageCube eventually gets deleted.
     sphericalHarmonics_ = loadImageCube_->GetSphericalHarmonics();
 
     // Update dependencies

--- a/Source/Urho3D/Graphics/TextureCube.h
+++ b/Source/Urho3D/Graphics/TextureCube.h
@@ -28,6 +28,8 @@
 #include "../Math/SphericalHarmonics.h"
 #include "../Resource/ImageCube.h"
 
+#include <EASTL/optional.h>
+
 namespace Urho3D
 {
 
@@ -67,6 +69,9 @@ public:
     /// Get image data from a face's zero mip level. Only RGB and RGBA textures are supported.
     SharedPtr<Image> GetImage(CubeMapFace face);
 
+    /// Return spherical harmonics of the texture, if the source image provided them on load.
+    ea::optional<SphericalHarmonicsDot9> GetSphericalHarmonics() const { return sphericalHarmonics_; }
+
     /// Return render surface for one face.
     /// @property{get_renderSurfaces}
     RenderSurface* GetRenderSurface(CubeMapFace face) const { return Texture::GetRenderSurface(face); }
@@ -74,6 +79,8 @@ public:
 private:
     /// Face image files acquired during BeginLoad.
     SharedPtr<ImageCube> loadImageCube_;
+    /// Spherical harmonics, copied from the source image on load.
+    ea::optional<SphericalHarmonicsDot9> sphericalHarmonics_;
 };
 
 }

--- a/Source/Urho3D/Graphics/TextureCube.h
+++ b/Source/Urho3D/Graphics/TextureCube.h
@@ -70,7 +70,7 @@ public:
     SharedPtr<Image> GetImage(CubeMapFace face);
 
     /// Return spherical harmonics of the texture, if the source image provided them on load.
-    ea::optional<SphericalHarmonicsDot9> GetSphericalHarmonics() const { return sphericalHarmonics_; }
+    const ea::optional<SphericalHarmonicsDot9>& GetSphericalHarmonics() const { return sphericalHarmonics_; }
 
     /// Return render surface for one face.
     /// @property{get_renderSurfaces}

--- a/Source/Urho3D/Graphics/Zone.cpp
+++ b/Source/Urho3D/Graphics/Zone.cpp
@@ -395,34 +395,16 @@ void Zone::UpdateCachedData()
         SphericalHarmonicsDot9 sh;
         if (zoneTexture_)
         {
-            // Use spherical harmonics of the texture, if they were precalculated on load.
-            ea::optional<SphericalHarmonicsDot9> precalculated;
-            TextureCube* zoneTextureCube = zoneTexture_->Cast<TextureCube>();
-            if (zoneTextureCube)
-                precalculated = zoneTextureCube->GetSphericalHarmonics();
-
-            if (precalculated)
-                sh = *precalculated;
-            else
+            if (TextureCube* zoneTextureCube = zoneTexture_->Cast<TextureCube>())
             {
-                // Fall back to loading the source images and calculating from them.
-                const ea::string& zoneTextureName = zoneTexture_->GetName();
-                auto cache = GetSubsystem<ResourceCache>();
-                SharedPtr<ImageCube> zoneImage;
-                if (!zoneTextureName.empty())
-                    zoneImage = cache->GetTempResource<ImageCube>(zoneTextureName);
-
-                if (zoneImage)
+                if (const auto& shCached = zoneTextureCube->GetSphericalHarmonics())
+                    sh = *shCached;
+                else
                 {
                     URHO3D_LOGWARNING(
-                        "Spherical harmonics of cubemap '{}' are not precalculated, so they are calculated again "
-                        "from images on disk. Add <sh calculate=\"true\" /> to the cubemap XML to avoid this.",
-                        zoneTextureName);
-                    sh = zoneImage->GetOrCreateSphericalHarmonics();
+                        "Texture '{}' does not contain cached spherical harmonics. "
+                        "Add <sh ... /> tag to the texture XML file.");
                 }
-                else
-                    URHO3D_LOGWARNING(
-                        "Cannot extract spherical harmonics from Zone texture without corresponding resource in cache");
             }
         }
 

--- a/Source/Urho3D/Graphics/Zone.cpp
+++ b/Source/Urho3D/Graphics/Zone.cpp
@@ -395,14 +395,35 @@ void Zone::UpdateCachedData()
         SphericalHarmonicsDot9 sh;
         if (zoneTexture_)
         {
-            const ea::string& zoneTextureName = zoneTexture_->GetName();
-            auto cache = GetSubsystem<ResourceCache>();
-            auto zoneImage = !zoneTextureName.empty() ? cache->GetTempResource<ImageCube>(zoneTextureName) : nullptr;
-            if (zoneImage)
-                sh = zoneImage->GetOrCreateSphericalHarmonics();
+            // Use spherical harmonics of the texture, if they were precalculated on load.
+            ea::optional<SphericalHarmonicsDot9> precalculated;
+            TextureCube* zoneTextureCube = zoneTexture_->Cast<TextureCube>();
+            if (zoneTextureCube)
+                precalculated = zoneTextureCube->GetSphericalHarmonics();
+
+            if (precalculated)
+                sh = *precalculated;
             else
-                URHO3D_LOGWARNING(
-                    "Cannot extract spherical harmonics from Zone texture without corresponding resource in cache");
+            {
+                // Fall back to loading the source images and calculating from them.
+                const ea::string& zoneTextureName = zoneTexture_->GetName();
+                auto cache = GetSubsystem<ResourceCache>();
+                SharedPtr<ImageCube> zoneImage;
+                if (!zoneTextureName.empty())
+                    zoneImage = cache->GetTempResource<ImageCube>(zoneTextureName);
+
+                if (zoneImage)
+                {
+                    URHO3D_LOGWARNING(
+                        "Spherical harmonics of cubemap '{}' are not precalculated, so they are calculated again "
+                        "from images on disk. Add <sh calculate=\"true\" /> to the cubemap XML to avoid this.",
+                        zoneTextureName);
+                    sh = zoneImage->GetOrCreateSphericalHarmonics();
+                }
+                else
+                    URHO3D_LOGWARNING(
+                        "Cannot extract spherical harmonics from Zone texture without corresponding resource in cache");
+            }
         }
 
         cachedTextureLighting_.Restore(sh);

--- a/Source/Urho3D/Resource/ImageCube.cpp
+++ b/Source/Urho3D/Resource/ImageCube.cpp
@@ -79,6 +79,7 @@ bool ImageCube::BeginLoad(Deserializer& source)
     }
 
     faceImages_.clear();
+    cachedSphericalHarmonics_.reset();
 
     XMLElement textureElem = parametersXml_->GetRoot();
     XMLElement imageElem = textureElem.GetChild("image");
@@ -191,20 +192,6 @@ bool ImageCube::BeginLoad(Deserializer& source)
         }
     }
 
-    // Load spherical harmonics, if present.
-    cachedSphericalHarmonics_.reset();
-    if (XMLElement shElement = textureElem.GetChild("sh"))
-    {
-        cachedSphericalHarmonics_ = SphericalHarmonicsDot9{};
-        cachedSphericalHarmonics_->Ar_ = shElement.GetVector4("ar");
-        cachedSphericalHarmonics_->Ag_ = shElement.GetVector4("ag");
-        cachedSphericalHarmonics_->Ab_ = shElement.GetVector4("ab");
-        cachedSphericalHarmonics_->Br_ = shElement.GetVector4("br");
-        cachedSphericalHarmonics_->Bg_ = shElement.GetVector4("bg");
-        cachedSphericalHarmonics_->Bb_ = shElement.GetVector4("bb");
-        cachedSphericalHarmonics_->C_ = shElement.GetVector4("c");
-    }
-
     // Precalculate mip levels if async loading
     if (GetAsyncLoadState() == ASYNC_LOADING)
     {
@@ -230,6 +217,24 @@ bool ImageCube::BeginLoad(Deserializer& source)
 
             if (faceImage->GetWidth() != width_ || faceImage->GetHeight() != width_)
                 return false;
+        }
+    }
+
+    // Load spherical harmonics, if present, or calculate automatically if that is requested.
+    if (XMLElement shElement = textureElem.GetChild("sh"))
+    {
+        if (shElement.GetBool("calculate"))
+            cachedSphericalHarmonics_ = SphericalHarmonicsDot9(CalculateSphericalHarmonics());
+        else
+        {
+            cachedSphericalHarmonics_ = SphericalHarmonicsDot9{};
+            cachedSphericalHarmonics_->Ar_ = shElement.GetVector4("ar");
+            cachedSphericalHarmonics_->Ag_ = shElement.GetVector4("ag");
+            cachedSphericalHarmonics_->Ab_ = shElement.GetVector4("ab");
+            cachedSphericalHarmonics_->Br_ = shElement.GetVector4("br");
+            cachedSphericalHarmonics_->Bg_ = shElement.GetVector4("bg");
+            cachedSphericalHarmonics_->Bb_ = shElement.GetVector4("bb");
+            cachedSphericalHarmonics_->C_ = shElement.GetVector4("c");
         }
     }
 

--- a/Source/Urho3D/Resource/ImageCube.h
+++ b/Source/Urho3D/Resource/ImageCube.h
@@ -79,6 +79,8 @@ public:
     SphericalHarmonicsColor9 CalculateSphericalHarmonics() const;
     /// Return cached spherical harmonics or recalculate from image if cache is not available.
     SphericalHarmonicsDot9 GetOrCreateSphericalHarmonics() const;
+    /// Return spherical harmonics, if the loaded file provided or requested them.
+    ea::optional<SphericalHarmonicsDot9> GetSphericalHarmonics() const { return cachedSphericalHarmonics_; }
 
     /// Project UV onto cube.
     static Vector3 ProjectUVOnCube(CubeMapFace face, const Vector2& uv);

--- a/Source/Urho3D/Resource/ImageCube.h
+++ b/Source/Urho3D/Resource/ImageCube.h
@@ -80,7 +80,7 @@ public:
     /// Return cached spherical harmonics or recalculate from image if cache is not available.
     SphericalHarmonicsDot9 GetOrCreateSphericalHarmonics() const;
     /// Return spherical harmonics, if the loaded file provided or requested them.
-    ea::optional<SphericalHarmonicsDot9> GetSphericalHarmonics() const { return cachedSphericalHarmonics_; }
+    const ea::optional<SphericalHarmonicsDot9>& GetSphericalHarmonics() const { return cachedSphericalHarmonics_; }
 
     /// Project UV onto cube.
     static Vector3 ProjectUVOnCube(CubeMapFace face, const Vector2& uv);

--- a/bin/CoreData/Textures/DefaultSkybox.xml
+++ b/bin/CoreData/Textures/DefaultSkybox.xml
@@ -1,5 +1,7 @@
 <cubemap>
-<srgb enable="false" />
-<image name="DefaultSkybox.dds" />
-<filter mode="bilinear" />
+    <srgb enable="false" />
+    <image name="DefaultSkybox.dds" />
+    <filter mode="bilinear" />
+    <quality low="0" />
+    <sh calculate="true" />
 </cubemap>

--- a/bin/Data/Textures/Skybox.xml
+++ b/bin/Data/Textures/Skybox.xml
@@ -6,4 +6,5 @@
     <face name="BrightDay1_PosZ.dds" />
     <face name="BrightDay1_NegZ.dds" />
     <quality low="0" />
+    <sh calculate="true" />
 </cubemap>


### PR DESCRIPTION
Because of a graphical effect, I need to switch the sky reflection of water on and off. This means calling `Zone::SetZoneTexture()`. Every call makes `Zone` recompute its cached lighting: it loads the cubemap images from disk just to calculate the same spherical harmonics. With six 2048x2048 JPEG faces it takes 250 ms and causes a visible hitch.

This PR stores the spherical harmonics in `TextureCube` instead. They are calculated lazily: the first call still loads the images once, but after that they come from the cache, until the texture is reloaded.