### PR TITLE
Fix two bugs

### DIFF
--- a/Source/Urho3D/Graphics/ModelView.h
+++ b/Source/Urho3D/Graphics/ModelView.h
@@ -10,6 +10,8 @@
 #include "Urho3D/Math/BoundingBox.h"
 #include "Urho3D/Math/Color.h"
 
+#include <cassert>
+
 namespace Urho3D
 {
 

--- a/Source/Urho3D/Graphics/Zone.cpp
+++ b/Source/Urho3D/Graphics/Zone.cpp
@@ -403,7 +403,8 @@ void Zone::UpdateCachedData()
                 {
                     URHO3D_LOGWARNING(
                         "Texture '{}' does not contain cached spherical harmonics. "
-                        "Add <sh ... /> tag to the texture XML file.");
+                        "Add <sh ... /> tag to the texture XML file.",
+                        zoneTextureCube->GetName());
                 }
             }
         }


### PR DESCRIPTION
Fix two bugs:

- A bigger one: ModelView.h uses assert without including <cassert>. The library itself builds, but a project including this header won't.
- A smaller one: Log message's `{}` was missing its argument.
