### PR TITLE
Add #include <algorithm>, needed by std::find().

### DIFF
--- a/Source/Urho3D/Core/ProcessUtils.cpp
+++ b/Source/Urho3D/Core/ProcessUtils.cpp
@@ -28,6 +28,7 @@
 #include "Urho3D/IO/FileSystem.h"
 #include "Urho3D/IO/Log.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <fcntl.h>
 #include <thread>


### PR DESCRIPTION
`ProcessUtils.cpp` is missing `#include <algorithm>`, even though it uses `std::find()`.

This works on many toolchains, because the include comes from other headers. However, it fails on native MSYS2 (MinGW GCC 14), and this PR fixes it.